### PR TITLE
Fixing a bug in the Cart service

### DIFF
--- a/src/Contracts/ShopBaseInfo.php
+++ b/src/Contracts/ShopBaseInfo.php
@@ -11,4 +11,9 @@ interface ShopBaseInfo
      * @return string
      */
     public function getMyShopifyDomain();
+
+    /**
+     * @return string
+     */
+    public function getDomain();
 }

--- a/src/Services/Cart.php
+++ b/src/Services/Cart.php
@@ -16,7 +16,7 @@ class Cart extends Base
     public function get($cartToken, $password = null)
     {
 
-        $raw = $this->client->get('cart.json',[], $this->getCartCookie($cartToken), $password);
+        $raw = $this->client->get('cart.json',[], $this->getCartCookie($cartToken), $password, true);
 
         $raw['items'] = $this->unserializeItems($raw['items']);
         $cart = $this->unserializeModel($raw, CartModel::class);
@@ -34,7 +34,7 @@ class Cart extends Base
 
         $cookies = $this->getCartCookie($cartToken);
 
-        $raw = $this->client->post('cart/clear.json', [], [], $cookies , $password);
+        $raw = $this->client->post('cart/clear.json', [], [], $cookies , $password, true);
 
         /**
          * @var CartModel $cart
@@ -59,7 +59,7 @@ class Cart extends Base
         }
 
         if($needToUpdateCart){
-            $raw = $this->client->post("cart/update.json", [], ['note' => '','attributes' => $cart->getAttributes()], $this->getCartCookie($cartToken), $password);
+            $raw = $this->client->post("cart/update.json", [], ['note' => '','attributes' => $cart->getAttributes()], $this->getCartCookie($cartToken), $password, true);
 
             return $this->unserializeModel($raw, CartModel::class);
         }
@@ -77,7 +77,7 @@ class Cart extends Base
     {
         $serializedModel = ['cart' => $this->serializeModel($cart)];
 
-        $raw = $this->client->post("cart/update.json", [], $serializedModel, $this->getCartCookie($cartToken), $password);
+        $raw = $this->client->post("cart/update.json", [], $serializedModel, $this->getCartCookie($cartToken), $password, true);
 
         return $this->unserializeModel($raw, CartModel::class);
     }

--- a/src/Services/Client.php
+++ b/src/Services/Client.php
@@ -68,7 +68,7 @@ class Client
     {
         $headers = ['X-Shopify-Access-Token' => $this->shopAccessInfo->getToken()];
 
-        $domain = $frontendApi?$this->shopBaseInfo->getDomain():$this->shopBaseInfo->getMyShopifyDomain();
+        $domain = $frontendApi ? $this->shopBaseInfo->getDomain() : $this->shopBaseInfo->getMyShopifyDomain();
 
         $uri = new Uri(sprintf('https://%s/%s', $domain, $path));
         $uri = $uri->withQuery(http_build_query($params));
@@ -93,7 +93,7 @@ class Client
     {
         $headers = ['X-Shopify-Access-Token' => $this->shopAccessInfo->getToken(), 'Content-Type' => 'application/json', 'charset' => 'utf-8'];
 
-        $domain = $frontendApi?$this->shopBaseInfo->getDomain():$this->shopBaseInfo->getMyShopifyDomain();
+        $domain = $frontendApi ? $this->shopBaseInfo->getDomain() : $this->shopBaseInfo->getMyShopifyDomain();
 
         $uri = new Uri(sprintf('https://%s/%s', $domain, $path));
         $uri = $uri->withQuery(http_build_query($params));

--- a/src/Services/Client.php
+++ b/src/Services/Client.php
@@ -57,17 +57,20 @@ class Client
      * @param array $params
      * @param array $cookies
      * @param string $password
+     * @param bool $frontendApi
      *
      * If password is set it will auth to /password before it does anything. Useful for frontend calls.
      * Cookies is an array of SetCookie objects. See the Cart service for an example.
      *
      * @return array
      */
-    public function get($path, $params = [], array $cookies = [], $password = null)
+    public function get($path, $params = [], array $cookies = [], $password = null, $frontendApi = false)
     {
         $headers = ['X-Shopify-Access-Token' => $this->shopAccessInfo->getToken()];
 
-        $uri = new Uri(sprintf('https://%s/%s', $this->shopBaseInfo->getMyShopifyDomain(), $path));
+        $domain = $frontendApi?$this->shopBaseInfo->getDomain():$this->shopBaseInfo->getMyShopifyDomain();
+
+        $uri = new Uri(sprintf('https://%s/%s', $domain, $path));
         $uri = $uri->withQuery(http_build_query($params));
         $request = new Request('GET', $uri, $headers);
 
@@ -79,16 +82,20 @@ class Client
      * @param array $params
      * @param array $cookies
      * @param string $password
+     * @param bool $frontendApi
      *
      * If password is set it will auth to /password before it does anything. Useful for frontend calls.
      * Cookies is an array of SetCookie objects. See the Cart service for an example.
      *
      * @return array
      */
-    public function post($path, $params = [], $body, array $cookies = [], $password = null)
+    public function post($path, $params = [], $body, array $cookies = [], $password = null, $frontendApi = false)
     {
         $headers = ['X-Shopify-Access-Token' => $this->shopAccessInfo->getToken(), 'Content-Type' => 'application/json', 'charset' => 'utf-8'];
-        $uri = new Uri(sprintf('https://%s/%s', $this->shopBaseInfo->getMyShopifyDomain(), $path));
+
+        $domain = $frontendApi?$this->shopBaseInfo->getDomain():$this->shopBaseInfo->getMyShopifyDomain();
+
+        $uri = new Uri(sprintf('https://%s/%s', $domain, $path));
         $uri = $uri->withQuery(http_build_query($params));
 
         $json = \GuzzleHttp\json_encode($body);
@@ -157,17 +164,20 @@ class Client
         ];
 
         try {
+            $domain = $request->getUri()->getHost();
+
             if($password) {
 
-                $uri = new Uri(sprintf('https://%s/password', $this->shopBaseInfo->getMyShopifyDomain()));
+                $uri = new Uri(sprintf('https://%s/password', $domain));
                 $uri = $uri->withQuery(http_build_query(['password' => $password]));
                 $authRequest = new Request('GET', $uri);
                 $this->client->send($authRequest,$options);
 
             }
+
             foreach($cookies as $cookie) {
                 //set the cookies that were passed in for the next request
-                $cookie->setDomain($this->shopBaseInfo->getMyShopifyDomain());
+                $cookie->setDomain($domain);
                 $cookieJar->setCookie($cookie);
             }
 


### PR DESCRIPTION
When getting a cart using the frontend api when a shop has a vanity domain and a storefront password, you must use the vanity domain when both authenticating and using the api because a redirect happens that causes the cookie to not be valid on the new domain.

The change to the interface to require the vanity domain (getDomain()) might mean this is a breaking change, because even if you're not using cart you'll have to add a getDomain() method. 