### PR TITLE
Accept draft orders with line item props

### DIFF
--- a/src/Services/DraftOrder.php
+++ b/src/Services/DraftOrder.php
@@ -120,7 +120,11 @@ class DraftOrder extends Base
 
         $draftOrderModel->setLineItems($draftOrderLineItems);
         $draftOrderModel->setNote($cart->getNote());
-        $draftOrderModel->setNoteAttributes($cart->getAttributes());
+
+        $cartAttributes = $cart->getAttributes();
+        if (!empty($cartAttributes)) {
+            $draftOrderModel->setNoteAttributes([$cartAttributes]);
+        }
 
         return $draftOrderModel;
     }

--- a/src/Services/DraftOrderLineItem.php
+++ b/src/Services/DraftOrderLineItem.php
@@ -96,6 +96,11 @@ class DraftOrderLineItem extends Base
             }
         }
 
+        $lineItemProperties = $draftOrderLineItem->getProperties();
+        if (!empty($lineItemProperties)) {
+            $draftOrderLineItem->setProperties([$lineItemProperties]);
+        }
+
         return $draftOrderLineItem;
     }
 


### PR DESCRIPTION
- Draft orders with line item props or note attributes were being
refused with error note_attributes:expected Hash to be a Array
- It seems the draft order API expects line item properties and note attributes
to be wrapped in an array:
https://help.shopify.com/api/reference/draftorder#note-attributes-property