### PR TITLE
Support for pluggable client-side rate limiter

### DIFF
--- a/src/Contracts/ApiRateLimiter.php
+++ b/src/Contracts/ApiRateLimiter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace BoldApps\ShopifyToolkit\Contracts;
+
+/**
+ * ApiRateLimiter defines a client-side rate limiter.
+ */
+interface ApiRateLimiter
+{
+    /**
+     * Throttle using key for limit per interval.
+     */
+    public function throttle($key);
+}

--- a/src/Contracts/RateLimitKeyGenerator.php
+++ b/src/Contracts/RateLimitKeyGenerator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace BoldApps\ShopifyToolkit\Contracts;
+
+/**
+ * RateLimitKeyGenerator creates a key used for Shopify API rate limiting.
+ */
+interface RateLimitKeyGenerator
+{
+    /**
+     * Generate a rate limit key for a given shopify domain.
+     */
+    public function getKey($myShopifyDomain);
+}

--- a/tests/Services/ClientTest.php
+++ b/tests/Services/ClientTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace BoldApps\Common\Test\Services\Shopify;
+
+use \PHPUnit\Framework\TestCase;
+use BoldApps\ShopifyToolkit\Services\Client;
+use BoldApps\ShopifyToolkit\Models\Shop;
+use BoldApps\ShopifyToolkit\Contracts\ShopBaseInfo;
+use BoldApps\ShopifyToolkit\Contracts\ShopAccessInfo;
+use BoldApps\ShopifyToolkit\Contracts\ApiSleeper;
+use BoldApps\ShopifyToolkit\Contracts\ApiRateLimiter;
+use BoldApps\ShopifyToolkit\Contracts\RateLimitKeyGenerator;
+
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+
+class ClientTest extends TestCase
+{
+    protected $client;
+
+    protected $mockShopBaseInfo;
+
+    protected $mockShopAccessInfo;
+
+    protected $mockApiSleeper;
+
+    protected $mockRateLimiter;
+
+    protected $mockRateLimitKeyGenerator;
+
+    protected $myShopifyDomain;
+
+    protected function setUp()
+    {
+        $this->myShopifyDomain = 'fight-club.myshopify.com';
+
+        // shop base info
+        $this->mockShopBaseInfo = $this->getMockBuilder(ShopBaseInfo::class)->getMock();
+
+        // shop access info
+        $this->mockShopAccessInfo = $this->getMockBuilder(ShopAccessInfo::class)->getMock();
+
+        // api sleeper
+        $this->mockApiSleeper = $this->getMockBuilder(ApiSleeper::class)->getMock();
+    }
+
+
+    public function testClientWillThrottleWhenUsingARateLimiterWhenConfigured()
+    {
+        $times = 10;
+
+        // mock http client
+        $mock = new MockHandler([new Response(200)]);
+        $handler = HandlerStack::create($mock);
+        $mockHttpClient = new \GuzzleHttp\Client(['handler' => $handler]);
+
+
+        $generatedKey = 'shopify-api:'.$this->myShopifyDomain;
+
+        // mock rate limit key generator
+        $this->mockRateLimitKeyGenerator = $this->getMockBuilder(RateLimitKeyGenerator::class)->getMock();
+        $this->mockRateLimitKeyGenerator->expects($this->exactly($times))
+            ->method('getKey')
+            ->will($this->returnValue($generatedKey));
+
+        // mock rate limiter
+        $this->mockRateLimiter = $this->getMockBuilder(ApiRateLimiter::class)->getMock();
+        $this->mockRateLimiter->expects($this->exactly($times))
+            ->method('throttle')
+            ->with($generatedKey);
+
+
+        $this->mockShopBaseInfo->expects($this->any())
+            ->method('getMyShopifyDomain')
+            ->will($this->returnValue($this->myShopifyDomain));
+
+        $this->client = new Client($this->mockShopBaseInfo, $this->mockShopAccessInfo, $mockHttpClient,
+            $this->mockApiSleeper, $this->mockRateLimiter, $this->mockRateLimitKeyGenerator);
+
+        for($i = 0; $i < $times; $i++){
+            $raw = $this->client->get("admin/orders/1.json");
+        }
+    }
+}


### PR DESCRIPTION
Support for pluggable client-side rate limiter

Provide the ability to configure an optional client-side rate limiter. If not provided, do not attempt any throttling.

- ApiRateLimiter defines the interface for providing a client side rate limiter
- RateLimitKeyGenerator defines an interface for generating a rate limit key using a myshopify domain (and anything else provided in a key generator implementation)
