### PR TITLE
Throw an err for null response in Client

### DIFF
--- a/src/Services/Client.php
+++ b/src/Services/Client.php
@@ -211,6 +211,11 @@ class Client
         }
         catch (RequestException $e) {
             $response = $e->getResponse();
+
+            if(!$response) {
+                throw $e;
+            }
+
             switch ($response->getStatusCode()) {
                 case 401:
                     throw new UnauthorizedException($e->getMessage());


### PR DESCRIPTION
- During a request exception in Client, we do not currently check if the response is null before attempting to call `getStatusCode()`
- Results in `Symfony\Component\Debug\Exception\FatalThrowableError · Call to a member function getStatusCode() on null`
- Throw an err earlier so this doesn't happen anymore