### PR TITLE
Don't send empty attributes to update.json

### DIFF
--- a/src/Services/Cart.php
+++ b/src/Services/Cart.php
@@ -50,13 +50,14 @@ class Cart extends Base
         $cart = $this->unserializeModel($raw, CartModel::class);
 
         $needToUpdateCart = false;
+        $cartUpdateData = [];
 
-
-        if ($cart->getNote() !== '') {
+        if (!empty($cart->getNote())) {
             $needToUpdateCart = true;
+            $cartUpdateData['note'] = '';
         }
 
-        if(count($cart->getAttributes())) {
+        if (count($cart->getAttributes())) {
             //can't just set attributes to an empty array, gotta set the values to blank
             $clearedAttributes = $cart->getAttributes();
             foreach($clearedAttributes as &$attribute) {
@@ -64,10 +65,11 @@ class Cart extends Base
             }
             $needToUpdateCart = true;
             $cart->setAttributes($clearedAttributes);
+            $cartUpdateData['attributes'] = $clearedAttributes;
         }
 
-        if($needToUpdateCart){
-            $raw = $this->client->post("cart/update.json", [], ['note' => '','attributes' => $cart->getAttributes()], $this->getCartCookie($cartToken), $password, true);
+        if ($needToUpdateCart) {
+            $raw = $this->client->post("cart/update.json", [], $cartUpdateData, $this->getCartCookie($cartToken), $password, true);
 
             return $this->unserializeModel($raw, CartModel::class);
         }


### PR DESCRIPTION
- Sometimes note is null not empty string so sometimes an unnecessary update was
happening
- We were always updating both note and attributes if either needed an
update which caused an error when the attributes were empty because
shopify expects an object for attributes and an empty php array gets
parsed into a json array
- The error we're getting is "expected Array to be a Hash: attributes"