### PR TITLE
Make it clear that the rate limiter is required

### DIFF
--- a/src/Services/Client.php
+++ b/src/Services/Client.php
@@ -59,7 +59,7 @@ class Client
      * @param ApiSleeper $apiSleeper
      * @param ApiRateLimiter $rateLimiter
      */
-    public function __construct(ShopBaseInfo $shopBaseInfo, ShopAccessInfo $shopAccessInfo, GuzzleClient $client, ApiSleeper $apiSleeper, ApiRateLimiter $rateLimiter = null, RateLimitKeyGenerator $rateLimitKeyGenerator = null)
+    public function __construct(ShopBaseInfo $shopBaseInfo, ShopAccessInfo $shopAccessInfo, GuzzleClient $client, ApiSleeper $apiSleeper, ApiRateLimiter $rateLimiter, RateLimitKeyGenerator $rateLimitKeyGenerator)
     {
         $this->shopBaseInfo = $shopBaseInfo;
         $this->shopAccessInfo = $shopAccessInfo;
@@ -200,10 +200,8 @@ class Client
             }
 
             // rate limit
-            if($this->rateLimitingEnabled()) {
-                $key = $this->rateLimitKeyGenerator->getKey($this->shopBaseInfo->getMyShopifyDomain());
-                $this->rateLimiter->throttle($key);
-            }
+            $key = $this->rateLimitKeyGenerator->getKey($this->shopBaseInfo->getMyShopifyDomain());
+            $this->rateLimiter->throttle($key);
 
             $response = $this->client->send($request,$options);
 
@@ -235,13 +233,5 @@ class Client
         }
 
         return $result;
-        }
-
-
-    /**
-     * If rate limiting is enabled (rate limiter and key generator configured)
-     */
-    private function rateLimitingEnabled() {
-        return ($this->rateLimiter != null && $this->rateLimitKeyGenerator != null);
     }
 }


### PR DESCRIPTION
- This never actually worked
- You can't have an optional dependency by using null like this
- So really the rate limiter is already required and 1.2.12/13 was a
breaking change
- This just makes it clear that is the case