### PR TITLE
Implement getting all variants by the product ID

### DIFF
--- a/src/Models/Variant.php
+++ b/src/Models/Variant.php
@@ -61,6 +61,9 @@ class Variant implements Serializeable
     protected $title;
 
     /** @var int */
+    protected $inventoryItemId;
+
+    /** @var int */
     protected $inventoryQuantity;
 
     /** @var int */
@@ -357,6 +360,22 @@ class Variant implements Serializeable
     public function setTitle($title)
     {
         $this->title = $title;
+    }
+
+    /**
+     * @return int
+     */
+    public function getInventoryItemId()
+    {
+        return $this->inventoryItemId;
+    }
+
+    /**
+     * @param int $inventoryItemId
+     */
+    public function setInventoryItemId($inventoryItemId)
+    {
+        $this->inventoryItemId = $inventoryItemId;
     }
 
     /**

--- a/src/Services/Variant.php
+++ b/src/Services/Variant.php
@@ -50,6 +50,23 @@ class Variant extends Base
     }
 
     /**
+     * @param int   $productId
+     * @param array $filter
+     *
+     * @return Collection
+     */
+    public function getAllByProductId($productId, $filter = [])
+    {
+        $raw = $this->client->get("admin/products/$productId/variants.json", $filter);
+
+        $variants = array_map(function ($variant) {
+            return $this->unserializeModel($variant, ShopifyVariant::class);
+        }, $raw['variants']);
+
+        return new Collection($variants);
+    }
+
+    /**
      * @param ShopifyVariant $variant
      *
      * @return object

--- a/tests/VariantTest.php
+++ b/tests/VariantTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use BoldApps\ShopifyToolkit\Services\Client;
+use BoldApps\ShopifyToolkit\Models\Variant as ShopifyVariant;
+use BoldApps\ShopifyToolkit\Services\Variant as VariantService;
+
+class VariantTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var VariantService */
+    private $variantService;
+
+    protected function setUp()
+    {
+        /** @var Client $client */
+        $client = $this->createMock(Client::class);
+        $this->variantService = new VariantService($client);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyVariantSerializesProperly()
+    {
+        $variantEntity = $this->createVariantEntity();
+
+        $expected = $this->getVariantArray();
+        $actual = $this->variantService->serializeModel($variantEntity);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyVariantDeserializesProperly()
+    {
+        $variantJson = $this->getVariantJson();
+        $jsonArray = (array)json_decode($variantJson, true);
+
+        $expected = $this->createVariantEntity();
+        $actual = $this->variantService->unserializeModel($jsonArray, ShopifyVariant::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    private function createVariantEntity()
+    {
+        /** @var ShopifyVariant $variantEntity */
+        $variantEntity = $this->variantService->createFromArray($this->getVariantArray());
+
+        return $variantEntity;
+    }
+
+    private function getVariantJson()
+    {
+        return '{
+            "id": 5303296294944,
+            "product_id": 440883118112,
+            "title": "Spooky",
+            "price": "45.00",
+            "sku": "",
+            "position": 1,
+            "inventory_policy": "deny",
+            "compare_at_price": null,
+            "fulfillment_service": "manual",
+            "inventory_management": null,
+            "option1": "Spooky",
+            "option2": null,
+            "option3": null,
+            "created_at": "2017-12-08T13:35:42-05:00",
+            "updated_at": "2017-12-21T09:49:41-05:00",
+            "taxable": true,
+            "barcode": "",
+            "grams": 3000,
+            "image_id": null,
+            "inventory_quantity": 0,
+            "weight": 3,
+            "weight_unit": "kg",
+            "inventory_item_id": 5292496748576,
+            "old_inventory_quantity": 0,
+            "requires_shipping": true
+        }';
+    }
+
+    private function getVariantArray()
+    {
+        return [
+            'id' => 5303296294944,
+            'product_id' => 440883118112,
+            'title' => 'Spooky',
+            'price' => 45.0,
+            'sku' => '',
+            'position' => 1,
+            'inventory_policy' => 'deny',
+            'fulfillment_service' => 'manual',
+            'option1' => 'Spooky',
+            'created_at' => '2017-12-08T13:35:42-05:00',
+            'updated_at' => '2017-12-21T09:49:41-05:00',
+            'taxable' => true,
+            'barcode' => '',
+            'grams' => 3000,
+            'inventory_item_id' => 5292496748576,
+            'inventory_quantity' => 0,
+            'weight' => '3',
+            'weight_unit' => 'kg',
+            'old_inventory_quantity' => 0,
+            'requires_shipping' => true,
+        ];
+    }
+}


### PR DESCRIPTION
- New function in the variant service to [grab all variants for a product using the product's ID](https://help.shopify.com/api/reference/product_variant#index)
- Added tests for serializing/unserializing variant `json`
- Also added a new variant param `'inventory_item_id'` that isn't on the Shopify Variant API page but it's included in the current json that is returned from this endpoint

![screen shot 2017-12-22 at 10 43 09 am](https://user-images.githubusercontent.com/12076625/34305709-ff73206a-e704-11e7-91b7-7541435ff6ca.png)
