### PR TITLE
Add support for collects endpoints

### DIFF
--- a/src/Models/Collect.php
+++ b/src/Models/Collect.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace BoldApps\ShopifyToolkit\Models;
+
+use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+
+class Collect implements Serializeable
+{
+    /** @var int */
+    protected $id;
+
+    /** @var int */
+    protected $collectionId;
+
+    /** @var int */
+    protected $productId;
+
+    /** @var bool */
+    protected $featured;
+
+    /** @var int */
+    protected $position;
+
+    /** @var string */
+    protected $sortValue;
+
+    /** @var string */
+    protected $createdAt;
+
+    /** @var string */
+    protected $updatedAt;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCollectionId()
+    {
+        return $this->collectionId;
+    }
+
+    /**
+     * @param int $collectionId
+     */
+    public function setCollectionId($collectionId)
+    {
+        $this->collectionId = $collectionId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getProductId()
+    {
+        return $this->productId;
+    }
+
+    /**
+     * @param int $productId
+     */
+    public function setProductId($productId)
+    {
+        $this->productId = $productId;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getFeatured()
+    {
+        return $this->featured;
+    }
+
+    /**
+     * @param bool $featured
+     */
+    public function setFeatured($featured)
+    {
+        $this->featured = $featured;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    /**
+     * @param int $position
+     */
+    public function setPosition($position)
+    {
+        $this->position = $position;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSortValue()
+    {
+        return $this->sortValue;
+    }
+
+    /**
+     * @param string $sortValue
+     */
+    public function setSortValue($sortValue)
+    {
+        $this->sortValue = $sortValue;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param string $createdAt
+     */
+    public function setCreatedAt($createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param string $updatedAt
+     */
+    public function setUpdatedAt($updatedAt)
+    {
+        $this->updatedAt = $updatedAt;
+    }
+}

--- a/src/Services/Collect.php
+++ b/src/Services/Collect.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace BoldApps\ShopifyToolkit\Services;
+
+use BoldApps\ShopifyToolkit\Models\Collect as ShopifyCollect;
+use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
+use Illuminate\Support\Collection;
+
+class Collect extends Base
+{
+    /**
+     * Collect constructor.
+     *
+     * @param ShopifyClient $client
+     */
+    public function __construct(ShopifyClient $client)
+    {
+        parent::__construct($client);
+    }
+
+    /**
+     * @param ShopifyCollect $collect
+     *
+     * @return ShopifyCollect | object
+     */
+    public function create(ShopifyCollect $collect)
+    {
+        $serializedModel = ['collect' => array_merge($this->serializeModel($collect))];
+
+        $raw = $this->client->post('admin/collects.json', [], $serializedModel);
+
+        return $this->unserializeModel($raw['collect'], ShopifyCollect::class);
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return ShopifyCollect | object
+     */
+    public function getById($id)
+    {
+        $raw = $this->client->get("admin/collects/$id.json");
+
+        return $this->unserializeModel($raw['collect'], ShopifyCollect::class);
+    }
+
+    /**
+     * @param array $params
+     *
+     * @return Collection
+     */
+    public function getByParams($params = [])
+    {
+        $raw = $this->client->get('admin/collects.json', $params);
+
+        $priceRules = array_map(function ($collect) {
+            return $this->unserializeModel($collect, ShopifyCollect::class);
+        }, $raw['collects']);
+
+        return new Collection($priceRules);
+    }
+
+    /**
+     * @param array $params
+     *
+     * @return Collection
+     */
+    public function count($params = [])
+    {
+        $raw = $this->client->get('admin/collects/count.json', $params);
+
+        return $raw['count'];
+    }
+
+    /**
+     * @param ShopifyCollect $collect
+     *
+     * @return ShopifyCollect | array
+     */
+    public function delete(ShopifyCollect $collect)
+    {
+        return $this->client->delete("admin/collects/{$collect->getId()}.json");
+    }
+
+    /**
+     * @param $array
+     *
+     * @return object
+     */
+    public function createFromArray($array)
+    {
+        return $this->unserializeModel($array, ShopifyCollect::class);
+    }
+}

--- a/tests/CollectTest.php
+++ b/tests/CollectTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use BoldApps\ShopifyToolkit\Models\Collect as ShopifyCollect;
+use BoldApps\ShopifyToolkit\Services\Client;
+use BoldApps\ShopifyToolkit\Services\Collect as CollectService;
+
+class CollectTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var CollectService */
+    private $collectService;
+
+    protected function setUp()
+    {
+        /** @var Client $client */
+        $client = $this->createMock(Client::class);
+        $this->collectService = new CollectService($client);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyCollectSerializesProperly()
+    {
+        $collectEntity = $this->createCollectEntity();
+
+        $expected = $this->getCollectArray();
+        $actual = $this->collectService->serializeModel($collectEntity);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyCollectDeserializesProperly()
+    {
+        $collectJson = $this->getCollectJson();
+        $jsonArray = (array)json_decode($collectJson, true);
+
+        $expected = $this->createCollectEntity();
+        $actual = $this->collectService->unserializeModel($jsonArray, ShopifyCollect::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    private function createCollectEntity()
+    {
+        /** @var ShopifyCollect $collectEntity */
+        $collectEntity = $this->collectService->createFromArray($this->getCollectArray());
+
+        return $collectEntity;
+    }
+
+    private function getCollectJson()
+    {
+        return '{
+            "id": 6254851031051,
+            "collection_id": 3465543691,
+            "product_id": 327661486091,
+            "featured": false,
+            "created_at": "2018-01-08T10:56:48-06:00",
+            "updated_at": "2018-01-08T10:56:48-06:00",
+            "position": 1,
+            "sort_value": "0000000001"
+        }';
+    }
+
+    private function getCollectArray()
+    {
+        return [
+            'id' => 6254851031051,
+            'collection_id' => 3465543691,
+            'product_id' => 327661486091,
+            'featured' => false,
+            'created_at' => '2018-01-08T10:56:48-06:00',
+            'updated_at' => '2018-01-08T10:56:48-06:00',
+            'position' => 1,
+            'sort_value' => '0000000001',
+        ];
+    }
+}


### PR DESCRIPTION
- This is so that we can easily retrieve product IDs via their collection ID

#### Changes
- Added functions for create, get, delete, and count endpoints
- Added a test for serializing and unserializing a collect model
- Reference can be found at https://help.shopify.com/api/reference/collect

#### Example `JSON`
<img width="442" alt="screen shot 2018-01-08 at 11 04 16 am" src="https://user-images.githubusercontent.com/12076625/34687849-948d58e6-f475-11e7-8c74-81f28330bc1f.png">

