### PR TITLE
Fix discount code retrieval and model

### DIFF
--- a/src/Models/DiscountCode.php
+++ b/src/Models/DiscountCode.php
@@ -1,34 +1,27 @@
 <?php
+
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
 
 class DiscountCode implements Serializeable
 {
-
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $id;
-    /**
-     * @var string
-     */
-    protected $code;
-    /**
-     * @var string
-     */
+
+    /** @var int */
     protected $priceRuleId;
-    /**
-     * @var string
-     */
+
+    /** @var string */
+    protected $code;
+
+    /** @var int */
     protected $usageCount;
-    /**
-     * @var string
-     */
+
+    /** @var string */
     protected $createdAt;
-    /**
-     * @var string
-     */
+
+    /** @var string */
     protected $updatedAt;
 
     /**
@@ -40,11 +33,59 @@ class DiscountCode implements Serializeable
     }
 
     /**
-     * @param $id
+     * @param int $id
      */
     public function setId($id)
     {
         $this->id = $id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPriceRuleId()
+    {
+        return $this->priceRuleId;
+    }
+
+    /**
+     * @param int $priceRuleId
+     */
+    public function setPriceRuleId($priceRuleId)
+    {
+        $this->priceRuleId = $priceRuleId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param string $code
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUsageCount()
+    {
+        return $this->usageCount;
+    }
+
+    /**
+     * @param int $usageCount
+     */
+    public function setUsageCount($usageCount)
+    {
+        $this->usageCount = $usageCount;
     }
 
     /**
@@ -61,53 +102,5 @@ class DiscountCode implements Serializeable
     public function getUpdatedAt()
     {
         return $this->updatedAt;
-    }
-
-    /**
-     * @return int
-     */
-    public function getCode()
-    {
-        return $this->code;
-    }
-
-    /**
-     * @param $code
-     */
-    public function setCode($code)
-    {
-        $this->code = $code;
-    }
-
-    /**
-     * @return int
-     */
-    public function getPriceRuleId()
-    {
-        return $this->priceRuleId;
-    }
-
-    /**
-     * @param $priceRuleId
-     */
-    public function setPriceRuleId($priceRuleId)
-    {
-        $this->priceRuleId = $priceRuleId;
-    }
-
-    /**
-     * @return int
-     */
-    public function getUsageCount()
-    {
-        return $this->usageCount;
-    }
-
-    /**
-     * @param $usageCount
-     */
-    public function setUsageCount($usageCount)
-    {
-        $this->usageCount = $usageCount;
     }
 }

--- a/src/Services/DiscountCode.php
+++ b/src/Services/DiscountCode.php
@@ -3,18 +3,14 @@
 namespace BoldApps\ShopifyToolkit\Services;
 
 use BoldApps\ShopifyToolkit\Models\DiscountCode as ShopifyDiscountCode;
+use Illuminate\Support\Collection;
 
-/**
- * Class DiscountCode
- * @package BoldApps\ShopifyToolkit\Services
- */
 class DiscountCode extends Base
 {
-
     /**
      * @param ShopifyDiscountCode $discountCode
      *
-     * @return ShopifyDiscountCode \ object
+     * @return ShopifyDiscountCode | object
      */
     public function create(ShopifyDiscountCode $discountCode)
     {
@@ -25,15 +21,42 @@ class DiscountCode extends Base
         return $this->unserializeModel($raw['discount_code'], ShopifyDiscountCode::class);
     }
 
+    /**
+     * @param $array
+     *
+     * @return object
+     */
+    public function createFromArray($array)
+    {
+        return $this->unserializeModel($array, ShopifyDiscountCode::class);
+    }
 
     /**
-     * @param $id
+     * @param int   $priceRuleId
+     * @param array $filter
      *
-     * @return ShopifyDiscountCode \ object
+     * @return Collection
      */
-    public function getById($id)
+    public function getAllByPriceRuleId($priceRuleId, $filter = [])
     {
-        $raw = $this->client->get("admin/price_rules/$id/discount_codes.json");
+        $raw = $this->client->get("admin/price_rules/$priceRuleId/discount_codes.json", $filter);
+
+        $discountCodes = array_map(function ($discountCode) {
+            return $this->unserializeModel($discountCode, ShopifyDiscountCode::class);
+        }, $raw['discount_codes']);
+
+        return new Collection($discountCodes);
+    }
+
+    /**
+     * @param int $priceRuleId
+     * @param int $discountCodeId
+     *
+     * @return ShopifyDiscountCode | object
+     */
+    public function getByDiscountCodeId($priceRuleId, $discountCodeId)
+    {
+        $raw = $this->client->get("admin/price_rules/$priceRuleId/discount_codes/$discountCodeId.json");
 
         return $this->unserializeModel($raw['discount_code'], ShopifyDiscountCode::class);
     }
@@ -55,11 +78,12 @@ class DiscountCode extends Base
     /**
      * @param ShopifyDiscountCode $discountCode
      *
-     * @return object
+     * @return array
      */
     public function delete(ShopifyDiscountCode $discountCode)
     {
         $priceRuleId = $discountCode->getPriceRuleId();
+
         return $this->client->delete("admin/price_rules/$priceRuleId/discount_codes/{$discountCode->getId()}.json");
     }
 }

--- a/tests/DiscountCodeTest.php
+++ b/tests/DiscountCodeTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use BoldApps\ShopifyToolkit\Services\Client;
+use BoldApps\ShopifyToolkit\Models\DiscountCode as ShopifyDiscountCode;
+use BoldApps\ShopifyToolkit\Services\DiscountCode as DiscountCodeService;
+
+class DiscountCodeTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var DiscountCodeService */
+    private $discountCodeService;
+
+    protected function setUp()
+    {
+        /** @var Client $client */
+        $client = $this->createMock(Client::class);
+        $this->discountCodeService = new DiscountCodeService($client);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyDiscountCodeSerializesProperly()
+    {
+        $discountCodeEntity = $this->createDiscountCodeEntity();
+
+        $expected = $this->getDiscountCodeArray();
+        $actual = $this->discountCodeService->serializeModel($discountCodeEntity);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyDiscountCodeDeserializesProperly()
+    {
+        $discountCodeJson = $this->getDiscountCodeJson();
+        $jsonArray = (array)json_decode($discountCodeJson, true);
+
+        $expected = $this->createDiscountCodeEntity();
+        $actual = $this->discountCodeService->unserializeModel($jsonArray, ShopifyDiscountCode::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    private function createDiscountCodeEntity()
+    {
+        /** @var ShopifyDiscountCode $discountCodeEntity */
+        $discountCodeEntity = $this->discountCodeService->createFromArray($this->getDiscountCodeArray());
+
+        return $discountCodeEntity;
+    }
+
+    private function getDiscountCodeJson()
+    {
+        return '{
+            "id": 48528162827,
+            "price_rule_id": 19275055115,
+            "code": "CARDINAL",
+            "usage_count": 0,
+            "created_at": "2018-01-02T11:54:46-06:00",
+            "updated_at": "2018-01-02T11:55:11-06:00"
+        }';
+    }
+
+    private function getDiscountCodeArray()
+    {
+        return [
+            "id" => 48528162827,
+            "price_rule_id" => 19275055115,
+            "code" => "CARDINAL",
+            "usage_count" => 0,
+            "created_at" => "2018-01-02T11:54:46-06:00",
+            "updated_at" => "2018-01-02T11:55:11-06:00",
+        ];
+    }
+}


### PR DESCRIPTION
- Corrected discount code model types to be consistent with types returned from the API
- Refactor discount code service to correct function for retrieving discount codes by price rule ID
  - Originally it assumed that one discount code was always returned [but that endpoint can return multiple discount codes per price rule ID](https://help.shopify.com/api/reference/discountcode#index)
  - Was also using wrong index on the `$raw` param for the above reason
  - Corrected such that it returns a collection of `discount_codes`
- Added function for [retrieving singular discount](https://help.shopify.com/api/reference/discountcode#show) codes by price rule ID + discount code ID
- Added test to ensure accuracy of serializing and de-serializing

<img width="789" alt="screen shot 2018-02-06 at 9 08 16 am" src="https://user-images.githubusercontent.com/12076625/35881605-f6e2884e-0b46-11e8-8c3f-ea20de796b00.png">
