### PR TITLE
Add customers endpoint to customer saved searches

### DIFF
--- a/src/Models/CustomerSavedSearch.php
+++ b/src/Models/CustomerSavedSearch.php
@@ -4,21 +4,22 @@ namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
 
-/**
- * Class CustomerSavedSearch
- * @package BoldApps\ShopifyToolkit\Models
- */
 class CustomerSavedSearch implements Serializeable
 {
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $id;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name;
+
+    /** @var string */
+    protected $query;
+
+    /** @var string */
+    protected $createdAt;
+
+    /** @var string */
+    protected $updatedAt;
 
     /**
      * @return int
@@ -69,7 +70,18 @@ class CustomerSavedSearch implements Serializeable
     }
 
     /**
-     * @var string
+     * @return string
      */
-    protected $query;
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
+    }
 }

--- a/src/Services/Customer.php
+++ b/src/Services/Customer.php
@@ -5,9 +5,6 @@ namespace BoldApps\ShopifyToolkit\Services;
 use BoldApps\ShopifyToolkit\Models\Customer as ShopifyCustomer;
 use Illuminate\Support\Collection;
 
-/**
- * Class Customer.
- */
 class Customer extends CollectionEntity
 {
     /**
@@ -96,6 +93,16 @@ class Customer extends CollectionEntity
     }
 
     /**
+     * @param $array
+     *
+     * @return ShopifyCustomer | object
+     */
+    public function createFromArray($array)
+    {
+        return $this->unserializeModel($array, ShopifyCustomer::class);
+    }
+
+    /**
      * @param ShopifyCustomer $customer
      *
      * @return ShopifyCustomer | object
@@ -134,7 +141,7 @@ class Customer extends CollectionEntity
     }
 
     /**
-     * @param int $shopifyCustomerId
+     * @param int   $shopifyCustomerId
      * @param array $params
      * @param array $body
      *

--- a/src/Services/CustomerSavedSearch.php
+++ b/src/Services/CustomerSavedSearch.php
@@ -2,14 +2,11 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Models\Customer as CustomerModel;
 use BoldApps\ShopifyToolkit\Models\CustomerSavedSearch as CustomerSavedSearchModel;
 use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
 use Illuminate\Support\Collection;
 
-/**
- * Class CustomerSavedSearch
- * @package BoldApps\ShopifyToolkit\Services
- */
 class CustomerSavedSearch extends CollectionEntity
 {
     /**
@@ -82,6 +79,23 @@ class CustomerSavedSearch extends CollectionEntity
         $customers = array_map(function ($customer) {
             return $this->unserializeModel($customer, CustomerSavedSearchModel::class);
         }, $raw['customer_saved_searches']);
+
+        return new Collection($customers);
+    }
+
+    /**
+     * @param int   $customerSavedSearchId
+     * @param array $params
+     *
+     * @return Collection
+     */
+    public function getAllCustomersById($customerSavedSearchId, $params = [])
+    {
+        $raw = $this->client->get("admin/customer_saved_searches/$customerSavedSearchId/customers.json", $params);
+
+        $customers = array_map(function ($customer) {
+            return $this->unserializeModel($customer, CustomerModel::class);
+        }, $raw['customers']);
 
         return new Collection($customers);
     }

--- a/tests/CustomerSavedSearchTest.php
+++ b/tests/CustomerSavedSearchTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use BoldApps\ShopifyToolkit\Services\Client;
+use BoldApps\ShopifyToolkit\Models\CustomerSavedSearch as ShopifyCustomerSavedSearch;
+use BoldApps\ShopifyToolkit\Services\CustomerSavedSearch as CustomerSavedSearchService;
+
+class CustomerSavedSearchTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var CustomerSavedSearchService */
+    private $customerSavedSearchService;
+
+    protected function setUp()
+    {
+        /** @var Client $client */
+        $client = $this->createMock(Client::class);
+        $this->customerSavedSearchService = new CustomerSavedSearchService($client);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyCustomerSavedSearchSerializesProperly()
+    {
+        $customerSavedSearchEntity = $this->createCustomerSavedSearchEntity();
+
+        $expected = $this->getCustomerSavedSearchArray();
+        $actual = $this->customerSavedSearchService->serializeModel($customerSavedSearchEntity);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyCustomerSavedSearchDeserializesProperly()
+    {
+        $customerSavedSearchJson = $this->getCustomerSavedSearchJson();
+        $jsonArray = (array)json_decode($customerSavedSearchJson, true);
+
+        $expected = $this->createCustomerSavedSearchEntity();
+        $actual = $this->customerSavedSearchService->unserializeModel($jsonArray, ShopifyCustomerSavedSearch::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    private function createCustomerSavedSearchEntity()
+    {
+        /** @var ShopifyCustomerSavedSearch $customerSavedSearchEntity */
+        $customerSavedSearchEntity = $this->customerSavedSearchService->createFromArray($this->getCustomerSavedSearchArray());
+
+        return $customerSavedSearchEntity;
+    }
+
+    private function getCustomerSavedSearchJson()
+    {
+        return '{
+            "id": 1862334091,
+            "name": "Abandoned checkouts",
+            "created_at": "2017-05-25T10:02:43-05:00",
+            "updated_at": "2017-05-25T10:02:43-05:00",
+            "query": "last_abandoned_order_date:last_month"
+        }';
+    }
+
+    private function getCustomerSavedSearchArray()
+    {
+        return [
+            "id" => 1862334091,
+            "name" => "Abandoned checkouts",
+            "created_at" => "2017-05-25T10:02:43-05:00",
+            "updated_at" => "2017-05-25T10:02:43-05:00",
+            "query" => "last_abandoned_order_date:last_month",
+        ];
+    }
+}

--- a/tests/CustomerTest.php
+++ b/tests/CustomerTest.php
@@ -1,0 +1,177 @@
+<?php
+
+use BoldApps\ShopifyToolkit\Services\Client;
+use BoldApps\ShopifyToolkit\Models\Customer as ShopifyCustomer;
+use BoldApps\ShopifyToolkit\Services\Customer as CustomerService;
+
+class CustomerTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var CustomerService */
+    private $customerService;
+
+    protected function setUp()
+    {
+        /** @var Client $client */
+        $client = $this->createMock(Client::class);
+        $this->customerService = new CustomerService($client);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyCustomerSerializesProperly()
+    {
+        $customerEntity = $this->createCustomerEntity();
+
+        $expected = $this->getCustomerArray();
+        $actual = $this->customerService->serializeModel($customerEntity);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyCustomerDeserializesProperly()
+    {
+        $customerJson = $this->getCustomerJson();
+        $jsonArray = (array)json_decode($customerJson, true);
+
+        $expected = $this->createCustomerEntity();
+        $actual = $this->customerService->unserializeModel($jsonArray, ShopifyCustomer::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    private function createCustomerEntity()
+    {
+        /** @var ShopifyCustomer $customerEntity */
+        $customerEntity = $this->customerService->createFromArray($this->getCustomerArray());
+
+        return $customerEntity;
+    }
+
+    private function getCustomerJson()
+    {
+        return '{
+            "id": 4391204235,
+            "email": "test@email.com",
+            "accepts_marketing": false,
+            "created_at": "2017-05-25T14:18:37-05:00",
+            "updated_at": "2018-01-31T18:07:21-06:00",
+            "first_name": "First",
+            "last_name": "Last",
+            "orders_count": 102,
+            "state": "enabled",
+            "total_spent": "13243.97",
+            "last_order_id": 148960968715,
+            "note": "",
+            "verified_email": true,
+            "multipass_identifier": null,
+            "tax_exempt": false,
+            "phone": "+12040000000",
+            "tags": "",
+            "last_order_name": "#1102",
+            "addresses": [{
+                "id": 4797872459,
+                "customer_id": 4391204235,
+                "first_name": "First",
+                "last_name": "Last",
+                "company": "Bold",
+                "address1": "50 Fultz Blvd",
+                "address2": "",
+                "city": "Winnipeg",
+                "province": "Manitoba",
+                "country": "Canada",
+                "zip": "R3Y 0L6",
+                "phone": "",
+                "name": "First Last",
+                "province_code": "MB",
+                "country_code": "CA",
+                "country_name": "Canada",
+                "default": true
+            }],
+            "default_address": {
+                "id": 4797872459,
+                "customer_id": 4391204235,
+                "first_name": "First",
+                "last_name": "Last",
+                "company": "Bold",
+                "address1": "50 Fultz Blvd",
+                "address2": "",
+                "city": "Winnipeg",
+                "province": "Manitoba",
+                "country": "Canada",
+                "zip": "R3Y 0L6",
+                "phone": "",
+                "name": "First Last",
+                "province_code": "MB",
+                "country_code": "CA",
+                "country_name": "Canada",
+                "default": true
+            }
+        }';
+    }
+
+    private function getCustomerArray()
+    {
+        return [
+            "id" => 4391204235,
+            "email" => "test@email.com",
+            "accepts_marketing" => false,
+            "created_at" => "2017-05-25T14:18:37-05:00",
+            "updated_at" => "2018-01-31T18:07:21-06:00",
+            "first_name" => "First",
+            "last_name" => "Last",
+            "orders_count" => 102,
+            "state" => "enabled",
+            "total_spent" => "13243.97",
+            "last_order_id" => 148960968715,
+            "note" => "",
+            "verified_email" => true,
+            "tax_exempt" => false,
+            "phone" => "+12040000000",
+            "tags" => "",
+            "last_order_name" => "#1102",
+            "addresses" => [[
+                "id" => 4797872459,
+                "customer_id" => 4391204235,
+                "first_name" => "First",
+                "last_name" => "Last",
+                "company" => "Bold",
+                "address1" => "50 Fultz Blvd",
+                "address2" => "",
+                "city" => "Winnipeg",
+                "province" => "Manitoba",
+                "country" => "Canada",
+                "zip" => "R3Y 0L6",
+                "phone" => "",
+                "name" => "First Last",
+                "province_code" => "MB",
+                "country_code" => "CA",
+                "country_name" => "Canada",
+                "default" => true,
+            ]],
+            "default_address" => [
+                "id" => 4797872459,
+                "customer_id" => 4391204235,
+                "first_name" => "First",
+                "last_name" => "Last",
+                "company" => "Bold",
+                "address1" => "50 Fultz Blvd",
+                "address2" => "",
+                "city" => "Winnipeg",
+                "province" => "Manitoba",
+                "country" => "Canada",
+                "zip" => "R3Y 0L6",
+                "phone" => "",
+                "name" => "First Last",
+                "province_code" => "MB",
+                "country_code" => "CA",
+                "country_name" => "Canada",
+                "default" => true,
+            ],
+        ];
+    }
+
+}


### PR DESCRIPTION
- Added dates to the customer saved search model
- Added function to customer saved search service that grabs all customers that apply to the customer saved search ID
  - [See endpoint here](https://help.shopify.com/api/reference/customersavedsearch#other)
- Added tests for customer and customer saved search to ensure accurate param types
- Added `createFromArray` function to customer service for easier testing

![screen shot 2018-02-07 at 1 19 53 pm](https://user-images.githubusercontent.com/12076625/35938140-e26c1a70-0c0d-11e8-9754-75c86f8ab279.png)
