### PR TITLE
Add a service for Shopify Country API

### DIFF
--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -6,31 +6,23 @@ use BoldApps\ShopifyToolkit\Contracts\Serializeable;
 
 class Country implements Serializeable
 {
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $id;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $code;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $provinces;
 
-    /**
-     * @var float
-     */
+    /** @var float */
     protected $tax;
 
+    /** @var string */
+    protected $taxName;
 
     /**
      * @return int
@@ -40,6 +32,13 @@ class Country implements Serializeable
         return $this->id;
     }
 
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
 
     /**
      * @return string
@@ -49,6 +48,13 @@ class Country implements Serializeable
         return $this->code;
     }
 
+    /**
+     * @param string $code
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
+    }
 
     /**
      * @return string
@@ -58,6 +64,13 @@ class Country implements Serializeable
         return $this->name;
     }
 
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
 
     /**
      * @return array
@@ -67,6 +80,13 @@ class Country implements Serializeable
         return $this->provinces;
     }
 
+    /**
+     * @param array $provinces
+     */
+    public function setProvinces($provinces)
+    {
+        $this->provinces = $provinces;
+    }
 
     /**
      * @return float
@@ -76,4 +96,27 @@ class Country implements Serializeable
         return $this->tax;
     }
 
+    /**
+     * @param float $tax
+     */
+    public function setTax($tax)
+    {
+        $this->tax = $tax;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTaxName()
+    {
+        return $this->taxName;
+    }
+
+    /**
+     * @param string $taxName
+     */
+    public function setTaxName($taxName)
+    {
+        $this->taxName = $taxName;
+    }
 }

--- a/src/Services/Country.php
+++ b/src/Services/Country.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace BoldApps\ShopifyToolkit\Services;
+
+use BoldApps\ShopifyToolkit\Models\Country as ShopifyCountry;
+
+class Country extends Base
+{
+    /**
+     * @param ShopifyCountry $country
+     *
+     * @return ShopifyCountry | object
+     */
+    public function create(ShopifyCountry $country)
+    {
+        $serializedModel = ['country' => $this->serializeModel($country)];
+
+        $raw = $this->client->post("admin/countries.json", [], $serializedModel);
+
+        return $this->unserializeModel($raw['country'], ShopifyCountry::class);
+    }
+
+    /**
+     * @param $array
+     *
+     * @return object
+     */
+    public function createFromArray($array)
+    {
+        return $this->unserializeModel($array, ShopifyCountry::class);
+    }
+
+    /**
+     * @param array $filter
+     *
+     * @return int
+     */
+    public function count($filter = [])
+    {
+        $raw = $this->client->get('admin/countries/count.json', $filter);
+
+        return $raw['count'];
+    }
+
+    /**
+     * @param array $filter
+     *
+     * @return ShopifyCountry | object
+     */
+    public function getAll($filter = [])
+    {
+        $raw = $this->client->get("admin/countries.json", $filter);
+
+        return $this->unserializeModel($raw['countries'], ShopifyCountry::class);
+    }
+
+    /**
+     * @param int   $countryId
+     * @param array $filter
+     *
+     * @return ShopifyCountry | object
+     */
+    public function getById($countryId, $filter = [])
+    {
+        $raw = $this->client->get("admin/countries/$countryId.json", $filter);
+
+        return $this->unserializeModel($raw['country'], ShopifyCountry::class);
+    }
+
+    /**
+     * @param ShopifyCountry $country
+     *
+     * @return object
+     */
+    public function update(ShopifyCountry $country)
+    {
+        $serializedModel = ['country' => $this->serializeModel($country)];
+        $raw = $this->client->put("admin/countries/{$country->getId()}.json", [], $serializedModel);
+
+        return $this->unserializeModel($raw['country'], ShopifyCountry::class);
+    }
+
+    /**
+     * @param ShopifyCountry $country
+     *
+     * @return array
+     */
+    public function delete(ShopifyCountry $country)
+    {
+        return $this->client->delete("admin/countries/{$country->getId()}.json");
+    }
+}

--- a/tests/CountryTest.php
+++ b/tests/CountryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use BoldApps\ShopifyToolkit\Services\Client;
+use BoldApps\ShopifyToolkit\Models\Country as ShopifyCountry;
+use BoldApps\ShopifyToolkit\Services\Country as CountryService;
+
+class CountryTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var CountryService */
+    private $countryService;
+
+    protected function setUp()
+    {
+        /** @var Client $client */
+        $client = $this->createMock(Client::class);
+        $this->countryService = new CountryService($client);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyCountrySerializesProperly()
+    {
+        $countryEntity = $this->createCountryEntity();
+
+        $expected = $this->getCountryArray();
+        $actual = $this->countryService->serializeModel($countryEntity);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyCountryDeserializesProperly()
+    {
+        $countryJson = $this->getCountryJson();
+        $jsonArray = (array)json_decode($countryJson, true);
+
+        $expected = $this->createCountryEntity();
+        $actual = $this->countryService->unserializeModel($jsonArray, ShopifyCountry::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    private function createCountryEntity()
+    {
+        /** @var ShopifyCountry $countryEntity */
+        $countryEntity = $this->countryService->createFromArray($this->getCountryArray());
+
+        return $countryEntity;
+    }
+
+    private function getCountryJson()
+    {
+        return '{
+            "id": 2644869131,
+            "name": "Australia",
+            "tax": 0,
+            "code": "AU",
+            "tax_name": "GST",
+            "provinces": [
+                {
+                    "id": 16168648715,
+                    "country_id": 2644869131,
+                    "name": "Australian Capital Territory",
+                    "code": "ACT",
+                    "tax": 0,
+                    "tax_name": "VAT",
+                    "tax_type": null,
+                    "shipping_zone_id": 496074763,
+                    "tax_percentage": 0
+                },
+                {
+                    "id": 16168681483,
+                    "country_id": 2644869131,
+                    "name": "New South Wales",
+                    "code": "NSW",
+                    "tax": 0,
+                    "tax_name": "VAT",
+                    "tax_type": null,
+                    "shipping_zone_id": 496074763,
+                    "tax_percentage": 0
+                }
+            ]
+        }';
+    }
+
+    private function getCountryArray()
+    {
+        return [
+            "id" => 2644869131,
+            "name" => "Australia",
+            "tax" => 0,
+            "code" => "AU",
+            "tax_name" => "GST",
+            "provinces" => [
+                [
+                    "id" => 16168648715,
+                    "country_id" => 2644869131,
+                    "name" => "Australian Capital Territory",
+                    "code" => "ACT",
+                    "tax" => 0,
+                    "tax_name" => "VAT",
+                    "tax_type" => null,
+                    "shipping_zone_id" => 496074763,
+                    "tax_percentage" => 0,
+                ],
+                [
+                    "id" => 16168681483,
+                    "country_id" => 2644869131,
+                    "name" => "New South Wales",
+                    "code" => "NSW",
+                    "tax" => 0,
+                    "tax_name" => "VAT",
+                    "tax_type" => null,
+                    "shipping_zone_id" => 496074763,
+                    "tax_percentage" => 0,
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
- Functions for `create`, `update`, `delete`, `getAll`, `getByCountryId`, `count`, and `createFromArray`
- Updates to the model to add setters for properties, as well as new `tax_name` prop
  - It's not listed as a property on the page but it is returned from hitting the endpoint
  - [See here](https://help.shopify.com/api/reference/country#index)
- Added test for serializing/unserializing countries to ensure property types