### PR TITLE
Switch to using isset rather than empty on translate prop trait

### DIFF
--- a/src/Traits/TranslatePropertiesTrait.php
+++ b/src/Traits/TranslatePropertiesTrait.php
@@ -15,7 +15,7 @@ trait TranslatePropertiesTrait {
     {
         $translatedOrderProperties = [];
         foreach ($orderProperties as $name => $value) {
-            if (!empty($name) && !empty($value)) {
+            if (!empty($name) && isset($value) ) {
                 $translatedOrderProperties[] = [
                     'name' => $name,
                     'value' => $value,


### PR DESCRIPTION
Bundles draft order is passing a value of 0 on a BOGO widget. The bundle price line item property is not getting set because of `empty()` treats 0 as an empty value. Proposing to switch using isset to allow for 0's.