### PR TITLE
When shopify has a 404, throw a specific NotFoundException

### DIFF
--- a/src/Exceptions/NotFoundException.php
+++ b/src/Exceptions/NotFoundException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BoldApps\ShopifyToolkit\Exceptions;
+
+class NotFoundException extends ShopifyException
+{
+
+}

--- a/src/Services/Client.php
+++ b/src/Services/Client.php
@@ -6,6 +6,7 @@ use BoldApps\ShopifyToolkit\Contracts\ShopBaseInfo;
 use BoldApps\ShopifyToolkit\Contracts\ShopAccessInfo;
 use BoldApps\ShopifyToolkit\Contracts\RequestHookInterface;
 use BoldApps\ShopifyToolkit\Exceptions\NotAcceptableException;
+use BoldApps\ShopifyToolkit\Exceptions\NotFoundException;
 use BoldApps\ShopifyToolkit\Exceptions\TooManyRequestsException;
 use BoldApps\ShopifyToolkit\Exceptions\UnauthorizedException;
 use BoldApps\ShopifyToolkit\Exceptions\UnprocessableEntityException;
@@ -166,6 +167,10 @@ class Client
      *
      * @return array|null
      * @throws UnauthorizedException
+     * @throws NotFoundException
+     * @throws NotAcceptableException
+     * @throws UnprocessableEntityException
+     * @throws TooManyRequestsException
      */
     private function sendRequestToShopify(Request $request, array $cookies = [], $password = null)
     {
@@ -211,6 +216,8 @@ class Client
             switch ($response->getStatusCode()) {
                 case 401:
                     throw new UnauthorizedException($e->getMessage());
+                case 404:
+                    throw new NotFoundException($e->getMessage());
                 case 406:
                     throw new NotAcceptableException($e->getMessage());
                 case 422:


### PR DESCRIPTION
This does not support backwards compatibility for people catching 404s in their own way
Added in a 404 to fix a refund bug that is trying to restock variants that no longer exist