### PR TITLE
Fix Asset service leaking NotFoundException

### DIFF
--- a/src/Services/Asset.php
+++ b/src/Services/Asset.php
@@ -2,12 +2,12 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\NotFoundException;
 use BoldApps\ShopifyToolkit\Models\Asset as AssetModel;
 use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
 use BoldApps\ShopifyToolkit\Services\Theme as ShopifyThemeService;
 use BoldApps\ShopifyToolkit\Models\Theme as ShopifyTheme;
 use Illuminate\Support\Collection;
-use GuzzleHttp\Exception\RequestException;
 
 /**
  * Class Asset.
@@ -72,18 +72,8 @@ class Asset extends Base
                 ],
             ]);
             $asset = $this->unserializeModel($raw['asset'], AssetModel::class);
-        } catch (RequestException $e) {
-            if (!$e->hasResponse()) {
-                throw $e;
-            }
-
-            switch ($e->getResponse()->getStatusCode()) {
-                case 404:
-                    $asset = null;
-                    break;
-                default:
-                    throw $e;
-            }
+        } catch (NotFoundException $e) {
+            $asset = null;
         }
 
         return $asset;


### PR DESCRIPTION
Client used to throw RequestException on 404, but now it throws NotFoundException.