### PR TITLE
Fix for create metafield url

### DIFF
--- a/src/Services/Shop.php
+++ b/src/Services/Shop.php
@@ -39,7 +39,7 @@ class Shop extends Base
     {
         $serializedModel = [ 'metafield' => array_merge($this->serializeModel($metafield)) ];
 
-        $raw = $this->client->post("admin/{$shop->getId()}/metafields.json", [], $serializedModel);
+        $raw = $this->client->post("admin/metafields.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['metafield'], ShopifyMetafield::class);
     }


### PR DESCRIPTION
In Shopify's API docs the URL to create metafields doesn't contain shop id