### PR TITLE
Modify PriceRule to reflect recent changes to the API

### DIFF
--- a/src/Models/PriceRule.php
+++ b/src/Models/PriceRule.php
@@ -49,6 +49,21 @@ class PriceRule implements Serializeable
     protected $prerequisiteShippingPriceRange;
 
     /** @var array */
+    protected $prerequisiteQuantityRange;
+
+    /** @var array */
+    protected $prerequisiteToEntitlementQuantityRatio;
+
+    /** @var array */
+    protected $prerequisiteVariantIds;
+
+    /** @var array */
+    protected $prerequisiteProductIds;
+
+    /** @var array */
+    protected $prerequisiteCollectionIds;
+
+    /** @var array */
     protected $entitledProductIds;
 
     /** @var array */
@@ -294,6 +309,86 @@ class PriceRule implements Serializeable
     public function setPrerequisiteShippingPriceRange($prerequisiteShippingPriceRange)
     {
         $this->prerequisiteShippingPriceRange = $prerequisiteShippingPriceRange;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPrerequisiteQuantityRange()
+    {
+        return $this->prerequisiteQuantityRange;
+    }
+
+    /**
+     * @param array $prerequisiteQuantityRange
+     */
+    public function setPrerequisiteQuantityRange($prerequisiteQuantityRange)
+    {
+        $this->prerequisiteQuantityRange = $prerequisiteQuantityRange;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPrerequisiteToEntitlementQuantityRatio()
+    {
+        return $this->prerequisiteToEntitlementQuantityRatio;
+    }
+
+    /**
+     * @param array $prerequisiteToEntitlementQuantityRatio
+     */
+    public function setPrerequisiteToEntitlementQuantityRatio($prerequisiteToEntitlementQuantityRatio)
+    {
+        $this->prerequisiteToEntitlementQuantityRatio = $prerequisiteToEntitlementQuantityRatio;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPrerequisiteVariantIds()
+    {
+        return $this->prerequisiteVariantIds;
+    }
+
+    /**
+     * @param array $prerequisiteVariantIds
+     */
+    public function setPrerequisiteVariantIds($prerequisiteVariantIds)
+    {
+        $this->prerequisiteVariantIds = $prerequisiteVariantIds;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPrerequisiteProductIds()
+    {
+        return $this->prerequisiteProductIds;
+    }
+
+    /**
+     * @param array $prerequisiteProductIds
+     */
+    public function setPrerequisiteProductIds($prerequisiteProductIds)
+    {
+        $this->prerequisiteProductIds = $prerequisiteProductIds;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPrerequisiteCollectionIds()
+    {
+        return $this->prerequisiteCollectionIds;
+    }
+
+    /**
+     * @param array $prerequisiteCollectionIds
+     */
+    public function setPrerequisiteCollectionIds($prerequisiteCollectionIds)
+    {
+        $this->prerequisiteCollectionIds = $prerequisiteCollectionIds;
     }
 
     /**

--- a/src/Services/PriceRule.php
+++ b/src/Services/PriceRule.php
@@ -68,6 +68,16 @@ class PriceRule extends CollectionEntity
     }
 
     /**
+     * @param $array
+     *
+     * @return object
+     */
+    public function createFromArray($array)
+    {
+        return $this->unserializeModel($array, ShopifyPriceRule::class);
+    }
+
+    /**
      * @param ShopifyPriceRule $priceRule
      *
      * @return ShopifyPriceRule | object

--- a/tests/PriceRuleTest.php
+++ b/tests/PriceRuleTest.php
@@ -21,7 +21,7 @@ class PriceRuleTest extends \PHPUnit\Framework\TestCase
      */
     public function ShopifyPriceRuleSerializesProperly()
     {
-        $priceRuleEntity = $this->createPriceRuleEntity();
+        $priceRuleEntity = $this->priceRuleService->createFromArray($this->getPriceRuleArray());
 
         $expected = $this->getPriceRuleArray();
         $actual = $this->priceRuleService->serializeModel($priceRuleEntity);
@@ -37,40 +37,10 @@ class PriceRuleTest extends \PHPUnit\Framework\TestCase
         $priceRuleJson = $this->getPriceRuleJson();
         $jsonArray = (array)json_decode($priceRuleJson, true);
 
-        $expected = $this->createPriceRuleEntity();
+        $expected = $this->priceRuleService->createFromArray($this->getPriceRuleArray());
         $actual = $this->priceRuleService->unserializeModel($jsonArray, ShopifyPriceRule::class);
 
         $this->assertEquals($expected, $actual);
-    }
-
-    private function createPriceRuleEntity()
-    {
-        /** @var ShopifyPriceRule $priceRuleEntity */
-        $priceRuleEntity = new ShopifyPriceRule();
-        $priceRuleEntity->setId(507328175);
-        $priceRuleEntity->setTitle('WINTER SALE');
-        $priceRuleEntity->setTargetType('line_item');
-        $priceRuleEntity->setTargetSelection('all');
-        $priceRuleEntity->setAllocationMethod('across');
-        $priceRuleEntity->setValueType('fixed_amount');
-        $priceRuleEntity->setValue("-10.0");
-        $priceRuleEntity->setOncePerCustomer(false);
-        $priceRuleEntity->setUsageLimit(null);
-        $priceRuleEntity->setCustomerSelection('all');
-        $priceRuleEntity->setPrerequisiteSavedSearchIds([]);
-        $priceRuleEntity->setPrerequisiteCustomerIds([]);
-        $priceRuleEntity->setPrerequisiteSubtotalRange(array("greater_than_or_equal_to" => "10.0"));
-        $priceRuleEntity->setPrerequisiteShippingPriceRange(array("less_than_or_equal_to" => "17.0"));
-        $priceRuleEntity->setEntitledProductIds([]);
-        $priceRuleEntity->setEntitledVariantIds([]);
-        $priceRuleEntity->setEntitledCollectionIds([]);
-        $priceRuleEntity->setEntitledCountryIds([]);
-        $priceRuleEntity->setStartsAt("2017-09-06T16:23:01-04:00");
-        $priceRuleEntity->setEndsAt("2017-09-18T16:23:01-04:00");
-        $priceRuleEntity->setCreatedAt("2017-09-12T16:23:01-04:00");
-        $priceRuleEntity->setUpdatedAt("2017-09-12T16:23:01-04:00");
-
-        return $priceRuleEntity;
     }
 
     private function getPriceRuleJson()
@@ -95,8 +65,16 @@ class PriceRuleTest extends \PHPUnit\Framework\TestCase
             "entitled_country_ids": [],
             "prerequisite_saved_search_ids": [],
             "prerequisite_customer_ids": [],
+            "prerequisite_product_ids": [],
+            "prerequisite_variant_ids": [],
+            "prerequisite_collection_ids": [],
             "prerequisite_subtotal_range": {"greater_than_or_equal_to": "10.0"},
+            "prerequisite_quantity_range": {"greater_than_or_equal_to": 5},
             "prerequisite_shipping_price_range": {"less_than_or_equal_to": "17.0"},
+            "prerequisite_to_entitlement_quantity_ratio": {
+                "prerequisite_quantity": 1,
+                "entitled_quantity": 2
+            },
             "title": "WINTER SALE"
         }';
     }
@@ -122,8 +100,13 @@ class PriceRuleTest extends \PHPUnit\Framework\TestCase
             "entitled_country_ids" => array(),
             "prerequisite_saved_search_ids" => array(),
             "prerequisite_customer_ids" => array(),
+            "prerequisite_product_ids" => array(),
+            "prerequisite_variant_ids" => array(),
+            "prerequisite_collection_ids" => array(),
             "prerequisite_subtotal_range" => array("greater_than_or_equal_to" => "10.0"),
+            "prerequisite_quantity_range" => array("greater_than_or_equal_to" => 5),
             "prerequisite_shipping_price_range" => array("less_than_or_equal_to" => "17.0"),
+            "prerequisite_to_entitlement_quantity_ratio" => array("prerequisite_quantity" => 1, "entitled_quantity" => 2),
             "title" => "WINTER SALE",
         ];
     }


### PR DESCRIPTION
- Shopify announced new type of discount for "Buy X Get Y"
- Adding the new property that corresponds to this: `"prerequisite_to_entitlement_quantity_ratio"`
  - https://help.shopify.com/api/reference/discounts/pricerule#prerequisite-to-entitlement-quantity-ratio-property
- Adjusting the test to account for this new property
- Also adding other new properties `"prerequisite_variant_ids"`, `"prequisite_product_ids"`, `"prerequsite_collection_ids"`, and `"prerequisite_quantity_range"`
  - The first three fields go hand in hand with the new BOGO discount, and the last one is another new general rule for product quantity

![screen shot 2018-05-14 at 11 44 29 am](https://user-images.githubusercontent.com/12076625/40011077-4fadebaa-576c-11e8-97b3-def4baebc222.png)