### PR TITLE
Redirect functionality for discount code endpoint

### DIFF
--- a/src/Services/DiscountCode.php
+++ b/src/Services/DiscountCode.php
@@ -62,6 +62,24 @@ class DiscountCode extends Base
     }
 
     /**
+     * @param string $discountCode
+     *
+     * @return ShopifyDiscountCode | object | null
+     */
+    public function lookup($discountCode)
+    {
+        $result = null;
+        $redirectLocation = $this->client->getRedirectLocation('admin/discount_codes/lookup.json', ['code' => $discountCode]);
+
+        if (!empty($redirectLocation)) {
+            $raw = $this->client->get($redirectLocation);
+            $result = $this->unserializeModel($raw['discount_code'], ShopifyDiscountCode::class);
+        }
+
+        return $result;
+    }
+
+    /**
      * @param ShopifyDiscountCode $discountCode
      *
      * @return object

--- a/tests/Services/ClientTest.php
+++ b/tests/Services/ClientTest.php
@@ -1,44 +1,47 @@
 <?php
+
 namespace BoldApps\Common\Test\Services\Shopify;
 
-use BoldApps\ShopifyToolkit\Exceptions\TooManyRequestsException;
-use \PHPUnit\Framework\TestCase;
-use BoldApps\ShopifyToolkit\Services\Client;
-use BoldApps\ShopifyToolkit\Models\Shop;
-use BoldApps\ShopifyToolkit\Contracts\ShopBaseInfo;
-use BoldApps\ShopifyToolkit\Contracts\ShopAccessInfo;
 use BoldApps\ShopifyToolkit\Contracts\RequestHookInterface;
+use BoldApps\ShopifyToolkit\Contracts\ShopAccessInfo;
+use BoldApps\ShopifyToolkit\Contracts\ShopBaseInfo;
+use BoldApps\ShopifyToolkit\Exceptions\NotFoundException;
+use BoldApps\ShopifyToolkit\Exceptions\TooManyRequestsException;
+use BoldApps\ShopifyToolkit\Services\Client;
 
-use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockBuilder as Mock;
 
 class ClientTest extends TestCase
 {
+    /** @var Client */
     protected $client;
 
+    /** @var Mock | ShopBaseInfo */
     protected $mockShopBaseInfo;
 
+    /** @var Mock | ShopAccessInfo */
     protected $mockShopAccessInfo;
 
+    /** @var Mock | RequestHookInterface */
     protected $mockRequestHookInterface;
 
+    /** @var string */
     protected $myShopifyDomain;
 
     protected function setUp()
     {
         $this->myShopifyDomain = 'fight-club.myshopify.com';
 
-        // shop base info
         $this->mockShopBaseInfo = $this->getMockBuilder(ShopBaseInfo::class)->getMock();
-
-        // shop access info
         $this->mockShopAccessInfo = $this->getMockBuilder(ShopAccessInfo::class)->getMock();
-
-        // request hook interface
         $this->mockRequestHookInterface = $this->getMockBuilder(RequestHookInterface::class)->getMock();
     }
-
 
     public function testClientWillThrottleWhenUsingARateLimiterWhenConfigured()
     {
@@ -60,7 +63,7 @@ class ClientTest extends TestCase
         $this->client = new Client($this->mockShopBaseInfo, $this->mockShopAccessInfo, $mockHttpClient,
             $this->mockRequestHookInterface);
 
-        for($i = 0; $i < $times; $i++){
+        for ($i = 0; $i < $times; $i++) {
             $raw = $this->client->get("admin/orders/1.json");
         }
     }
@@ -74,7 +77,7 @@ class ClientTest extends TestCase
 
         $this->mockShopBaseInfo->expects($this->any())
             ->method('getMyShopifyDomain')
-            ->will($this->returnValue($this->myShopifyDomain));;
+            ->will($this->returnValue($this->myShopifyDomain));
 
         $this->expectException(TooManyRequestsException::class);
 
@@ -82,5 +85,52 @@ class ClientTest extends TestCase
             $this->mockRequestHookInterface);
 
         $this->client->get("admin/orders/1.json");
+    }
+
+    /**
+     * @param null|string $expected
+     * @param int         $responseCode
+     * @param array       $responseHeader
+     * @param mixed       $exceptionClass
+     *
+     * @dataProvider getRedirectLocationProvider
+     */
+    public function testGetRedirectLocation($expected, $responseCode, $responseHeader, $exceptionClass)
+    {
+        $mock = new MockHandler([new Response($responseCode, $responseHeader)]);
+        $handler = HandlerStack::create($mock);
+        $mockHttpClient = new \GuzzleHttp\Client(['handler' => $handler]);
+
+        $this->mockShopBaseInfo->expects($this->any())
+            ->method('getMyShopifyDomain')
+            ->will($this->returnValue($this->myShopifyDomain));
+
+        if (!is_null($exceptionClass)) {
+            $this->expectException($exceptionClass);
+        }
+
+        $this->client = new Client($this->mockShopBaseInfo, $this->mockShopAccessInfo, $mockHttpClient,
+            $this->mockRequestHookInterface);
+
+        $result = $this->client->getRedirectLocation('admin/discount_codes/lookup.json', ['code' => 'DISCOUNT_CODE']);
+        $this->assertSame($expected, $result);
+    }
+
+    public static function getRedirectLocationProvider()
+    {
+        $shopDomain = 'coolshop.myshopify.com';
+        $adminURI = 'admin/price_rules/294645137513/discount_codes/1318545293417';
+
+        return [
+            ['expected' => null, 'responseCode' => 404, 'responseHeader' => [], 'exceptionClass' => NotFoundException::class],
+            ['expected' => null, 'responseCode' => 500, 'responseHeader' => [], 'exceptionClass' => RequestException::class],
+            ['expected' => null, 'responseCode' => 200, 'responseHeader' => [], 'exceptionClass' => null],
+            ['expected' => null, 'responseCode' => 303, 'responseHeader' => [], 'exceptionClass' => null],
+            ['expected' => null, 'responseCode' => 303, 'responseHeader' => ['Location' => []], 'exceptionClass' => null],
+            ['expected' => null, 'responseCode' => 303, 'responseHeader' => ['Connection' => ['keep-alive']], 'exceptionClass' => null],
+            ['expected' => null, 'responseCode' => 303, 'responseHeader' => ['Location' => ["this/is/not/a/valid/url"]], 'exceptionClass' => null],
+            ['expected' => "$adminURI.json", 'responseCode' => 303, 'responseHeader' => ['Location' => ["https://$shopDomain/$adminURI"]], 'exceptionClass' => null],
+            ['expected' => "$adminURI.json", 'responseCode' => 303, 'responseHeader' => ['Location' => ["https://$shopDomain/$adminURI.json"]], 'exceptionClass' => null],
+        ];
     }
 }


### PR DESCRIPTION
- Add support to the toolkit so that we can retrieve data from the [discount code API's lookup endpoint](https://help.shopify.com/api/reference/discounts/discountcode#lookup) correctly
- This means writing a new client `get` function that specifically does not follow the redirect but instead takes the location header from the redirect response
  - We are doing this because the redirect URL returned from Shopify's 303 response does not provide us JSON content, so when Guzzle attempts to follow this redirect and parse JSON from it, null is returned
- New `DiscountCode` service function for looking up a discount code, taking the redirect location, and performing a normal `get` on the returned `json` location of the discount code, otherwise if it's not found it will throw a `404 NotFoundException`