### PR TITLE
Allow model attributes to be accessed magically

### DIFF
--- a/src/Models/ApplicationCharge.php
+++ b/src/Models/ApplicationCharge.php
@@ -3,6 +3,7 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 /**
  * Class ApplicationCharge
@@ -10,6 +11,8 @@ use BoldApps\ShopifyToolkit\Contracts\Serializeable;
  */
 class ApplicationCharge implements Serializeable
 {
+    use HasAttributesTrait;
+
     /**
      * @var int
      */

--- a/src/Models/Asset.php
+++ b/src/Models/Asset.php
@@ -3,9 +3,12 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class Asset implements Serializeable
 {
+    use HasAttributesTrait;
+
     /** @var  string */
     protected $key;
 

--- a/src/Models/Collect.php
+++ b/src/Models/Collect.php
@@ -3,9 +3,12 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class Collect implements Serializeable
 {
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 

--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -3,9 +3,12 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class Country implements Serializeable
 {
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 

--- a/src/Models/CustomCollection.php
+++ b/src/Models/CustomCollection.php
@@ -3,11 +3,8 @@
 
 namespace BoldApps\ShopifyToolkit\Models;
 
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
-/**
- * Class CustomCollection
- * @package BoldApps\ShopifyToolkit\Models
- */
 /**
  * Class CustomCollection
  * @package BoldApps\ShopifyToolkit\Models
@@ -15,7 +12,9 @@ namespace BoldApps\ShopifyToolkit\Models;
 class CustomCollection
 {
 
-    /*** @var int*/
+    use HasAttributesTrait;
+
+    /*** @var int */
     protected $id;
 
     /*** @var string */
@@ -120,7 +119,8 @@ class CustomCollection
     /**
      * @return array
      */
-    public function getImage(){
+    public function getImage()
+    {
         return $this->image;
     }
 

--- a/src/Models/Customer.php
+++ b/src/Models/Customer.php
@@ -3,9 +3,12 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class Customer implements Serializeable
 {
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 
@@ -368,7 +371,7 @@ class Customer implements Serializeable
      */
     public function getSendWelcomeEmail()
     {
-        $this->sendWelcomeEmail;
+        return $this->sendWelcomeEmail;
     }
 
     /**

--- a/src/Models/CustomerAddress.php
+++ b/src/Models/CustomerAddress.php
@@ -3,9 +3,13 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class CustomerAddress implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 

--- a/src/Models/CustomerSavedSearch.php
+++ b/src/Models/CustomerSavedSearch.php
@@ -3,9 +3,13 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class CustomerSavedSearch implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 

--- a/src/Models/DiscountCode.php
+++ b/src/Models/DiscountCode.php
@@ -3,9 +3,13 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class DiscountCode implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 

--- a/src/Models/DraftOrder.php
+++ b/src/Models/DraftOrder.php
@@ -3,6 +3,7 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 use Illuminate\Support\Collection;
 
 /**
@@ -10,6 +11,9 @@ use Illuminate\Support\Collection;
  */
 class DraftOrder implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var  int */
     protected $id;
 
@@ -28,7 +32,7 @@ class DraftOrder implements Serializeable
     /** @var  string */
     protected $currency;
 
-    /** @var   string*/
+    /** @var   string */
     protected $subtotalPrice;
 
     /** @var  string */

--- a/src/Models/DraftOrderAppliedDiscount.php
+++ b/src/Models/DraftOrderAppliedDiscount.php
@@ -3,12 +3,16 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 /**
  * Class DraftOrderAppliedDiscount
  */
 class DraftOrderAppliedDiscount implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var  string */
     protected $title;
 

--- a/src/Models/DraftOrderLineItem.php
+++ b/src/Models/DraftOrderLineItem.php
@@ -3,12 +3,16 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 /**
  * Class DraftOrderLineItem
  */
 class DraftOrderLineItem implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /**
      * @var int
      */

--- a/src/Models/Fulfillment.php
+++ b/src/Models/Fulfillment.php
@@ -1,11 +1,15 @@
 <?php
+
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 
 class Fulfillment implements Serializeable
 {
+
+    use HasAttributesTrait;
 
     /** @var string */
     protected $createdAt;

--- a/src/Models/Image.php
+++ b/src/Models/Image.php
@@ -3,9 +3,13 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class Image implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 

--- a/src/Models/LineItem.php
+++ b/src/Models/LineItem.php
@@ -3,9 +3,13 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class LineItem implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /* @var string */
     protected $title;
 

--- a/src/Models/Metafield.php
+++ b/src/Models/Metafield.php
@@ -3,12 +3,16 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 /**
  * Class Metafield.
  */
 class Metafield implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var  int */
     protected $id;
 

--- a/src/Models/Option.php
+++ b/src/Models/Option.php
@@ -3,12 +3,16 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 /**
  * Class Option.
  */
 class Option implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var  int */
     protected $id;
 
@@ -59,7 +63,8 @@ class Option implements Serializeable
     /**
      * @param $values
      */
-    public function setValues($values) {
+    public function setValues($values)
+    {
         $this->values = $values;
     }
 

--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -3,10 +3,14 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 use Illuminate\Support\Collection;
 
 class Order implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 
@@ -136,7 +140,7 @@ class Order implements Serializeable
     /** @var string */
     protected $source;
 
-    /** @var id */
+    /** @var int */
     protected $checkoutId;
 
     /** @var string */
@@ -151,11 +155,14 @@ class Order implements Serializeable
     /** @var array */
     protected $discountCodes;
 
-    /** @var object */
+    /** @var array */
     protected $noteAttributes;
 
     /** @var array */
     protected $taxLines;
+
+    /** @var mixed */
+    protected $tax;
 
     /** @var Collection */
     protected $lineItems;
@@ -528,7 +535,7 @@ class Order implements Serializeable
 
     /**
      * @return int
-     9*/
+     */
     public function getCheckoutId()
     {
         return $this->checkoutId;
@@ -713,7 +720,8 @@ class Order implements Serializeable
     /**
      * @return string
      */
-    public function getTransactions() {
+    public function getTransactions()
+    {
         return $this->transactions;
     }
 
@@ -1046,7 +1054,7 @@ class Order implements Serializeable
     }
 
     /**
-     * @param id $checkoutId
+     * @param int $checkoutId
      */
     public function setCheckoutId($checkoutId)
     {
@@ -1200,7 +1208,8 @@ class Order implements Serializeable
     /**
      * @param array $transactions
      */
-    public function setTransactions($transactions) {
+    public function setTransactions($transactions)
+    {
         $this->transactions = $transactions;
     }
 

--- a/src/Models/OrderLineItem.php
+++ b/src/Models/OrderLineItem.php
@@ -3,6 +3,7 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 use Illuminate\Database\Eloquent\Collection;
 
 /**
@@ -10,181 +11,8 @@ use Illuminate\Database\Eloquent\Collection;
  */
 class OrderLineItem implements Serializeable
 {
-    /**
-     * @param int $id
-     */
-    public function setId(int $id)
-    {
-        $this->id = $id;
-    }
 
-    /**
-     * @param int $variantId
-     */
-    public function setVariantId(int $variantId)
-    {
-        $this->variantId = $variantId;
-    }
-
-    /**
-     * @param string $title
-     */
-    public function setTitle(string $title)
-    {
-        $this->title = $title;
-    }
-
-    /**
-     * @param int $quantity
-     */
-    public function setQuantity(int $quantity)
-    {
-        $this->quantity = $quantity;
-    }
-
-    /**
-     * @param string $price
-     */
-    public function setPrice(string $price)
-    {
-        $this->price = $price;
-    }
-
-    /**
-     * @param int $grams
-     */
-    public function setGrams(int $grams)
-    {
-        $this->grams = $grams;
-    }
-
-    /**
-     * @param string $sku
-     */
-    public function setSku(string $sku)
-    {
-        $this->sku = $sku;
-    }
-
-    /**
-     * @param string $variantTitle
-     */
-    public function setVariantTitle(string $variantTitle)
-    {
-        $this->variantTitle = $variantTitle;
-    }
-
-    /**
-     * @param string $vendor
-     */
-    public function setVendor(string $vendor)
-    {
-        $this->vendor = $vendor;
-    }
-
-    /**
-     * @param string $fulfillmentService
-     */
-    public function setFulfillmentService(string $fulfillmentService)
-    {
-        $this->fulfillmentService = $fulfillmentService;
-    }
-
-    /**
-     * @param int $productId
-     */
-    public function setProductId(int $productId)
-    {
-        $this->productId = $productId;
-    }
-
-    /**
-     * @param boolean $requiresShipping
-     */
-    public function setRequiresShipping(bool $requiresShipping)
-    {
-        $this->requiresShipping = $requiresShipping;
-    }
-
-    /**
-     * @param boolean $taxable
-     */
-    public function setTaxable(bool $taxable)
-    {
-        $this->taxable = $taxable;
-    }
-
-    /**
-     * @param boolean $giftCard
-     */
-    public function setGiftCard(bool $giftCard)
-    {
-        $this->giftCard = $giftCard;
-    }
-
-    /**
-     * @param string $name
-     */
-    public function setName(string $name)
-    {
-        $this->name = $name;
-    }
-
-    /**
-     * @param string $variantInventoryManagement
-     */
-    public function setVariantInventoryManagement(string $variantInventoryManagement)
-    {
-        $this->variantInventoryManagement = $variantInventoryManagement;
-    }
-
-    /**
-     * @param array $properties
-     */
-    public function setProperties(array $properties)
-    {
-        $this->properties = $properties;
-    }
-
-    /**
-     * @param boolean $productExists
-     */
-    public function setProductExists(bool $productExists)
-    {
-        $this->productExists = $productExists;
-    }
-
-    /**
-     * @param string $fulfillmentStatus
-     */
-    public function setFulfillmentStatus(string $fulfillmentStatus)
-    {
-        $this->fulfillmentStatus = $fulfillmentStatus;
-    }
-
-    /**
-     * @param Collection $taxLines
-     */
-    public function setTaxLines(Collection $taxLines)
-    {
-        $this->taxLines = $taxLines;
-    }
-
-    /**
-     * @param int $fulfillableQuantity
-     */
-    public function setFulfillableQuantity(int $fulfillableQuantity)
-    {
-        $this->fulfillableQuantity = $fulfillableQuantity;
-    }
-
-    /**
-     * @param int $totalDiscount
-     */
-    public function setTotalDiscount(int $totalDiscount)
-    {
-        $this->totalDiscount = $totalDiscount;
-    }
+    use HasAttributesTrait;
 
     /** @var  int */
     protected $id;
@@ -251,6 +79,182 @@ class OrderLineItem implements Serializeable
 
     /*** @var int */
     protected $totalDiscount;
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @param int $variantId
+     */
+    public function setVariantId($variantId)
+    {
+        $this->variantId = $variantId;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @param int $quantity
+     */
+    public function setQuantity($quantity)
+    {
+        $this->quantity = $quantity;
+    }
+
+    /**
+     * @param string $price
+     */
+    public function setPrice($price)
+    {
+        $this->price = $price;
+    }
+
+    /**
+     * @param int $grams
+     */
+    public function setGrams($grams)
+    {
+        $this->grams = $grams;
+    }
+
+    /**
+     * @param string $sku
+     */
+    public function setSku($sku)
+    {
+        $this->sku = $sku;
+    }
+
+    /**
+     * @param string $variantTitle
+     */
+    public function setVariantTitle($variantTitle)
+    {
+        $this->variantTitle = $variantTitle;
+    }
+
+    /**
+     * @param string $vendor
+     */
+    public function setVendor($vendor)
+    {
+        $this->vendor = $vendor;
+    }
+
+    /**
+     * @param string $fulfillmentService
+     */
+    public function setFulfillmentService($fulfillmentService)
+    {
+        $this->fulfillmentService = $fulfillmentService;
+    }
+
+    /**
+     * @param int $productId
+     */
+    public function setProductId($productId)
+    {
+        $this->productId = $productId;
+    }
+
+    /**
+     * @param boolean $requiresShipping
+     */
+    public function setRequiresShipping($requiresShipping)
+    {
+        $this->requiresShipping = $requiresShipping;
+    }
+
+    /**
+     * @param boolean $taxable
+     */
+    public function setTaxable($taxable)
+    {
+        $this->taxable = $taxable;
+    }
+
+    /**
+     * @param boolean $giftCard
+     */
+    public function setGiftCard($giftCard)
+    {
+        $this->giftCard = $giftCard;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @param string $variantInventoryManagement
+     */
+    public function setVariantInventoryManagement($variantInventoryManagement)
+    {
+        $this->variantInventoryManagement = $variantInventoryManagement;
+    }
+
+    /**
+     * @param array $properties
+     */
+    public function setProperties(array $properties)
+    {
+        $this->properties = $properties;
+    }
+
+    /**
+     * @param boolean $productExists
+     */
+    public function setProductExists($productExists)
+    {
+        $this->productExists = $productExists;
+    }
+
+    /**
+     * @param string $fulfillmentStatus
+     */
+    public function setFulfillmentStatus($fulfillmentStatus)
+    {
+        $this->fulfillmentStatus = $fulfillmentStatus;
+    }
+
+    /**
+     * @param Collection $taxLines
+     */
+    public function setTaxLines(Collection $taxLines)
+    {
+        $this->taxLines = $taxLines;
+    }
+
+    /**
+     * @param int $fulfillableQuantity
+     */
+    public function setFulfillableQuantity($fulfillableQuantity)
+    {
+        $this->fulfillableQuantity = $fulfillableQuantity;
+    }
+
+    /**
+     * @param int $totalDiscount
+     */
+    public function setTotalDiscount($totalDiscount)
+    {
+        $this->totalDiscount = $totalDiscount;
+    }
 
     /**
      * @return int

--- a/src/Models/PriceRule.php
+++ b/src/Models/PriceRule.php
@@ -3,9 +3,13 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class PriceRule implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -3,10 +3,14 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 use Illuminate\Support\Collection;
 
 class Product implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var  int */
     protected $id;
 

--- a/src/Models/Province.php
+++ b/src/Models/Province.php
@@ -3,9 +3,13 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class Province implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /**
      * @var int
      */

--- a/src/Models/RecurringApplicationCharge.php
+++ b/src/Models/RecurringApplicationCharge.php
@@ -3,6 +3,7 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 /**
  * Class RecurringApplicationCharge
@@ -10,6 +11,9 @@ use BoldApps\ShopifyToolkit\Contracts\Serializeable;
  */
 class RecurringApplicationCharge implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /**
      * @var int
      */

--- a/src/Models/Refund.php
+++ b/src/Models/Refund.php
@@ -3,11 +3,15 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 use Illuminate\Support\Collection;
 
 
 class Refund implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var  int */
     public $id;
 

--- a/src/Models/RefundLineItem.php
+++ b/src/Models/RefundLineItem.php
@@ -2,8 +2,13 @@
 
 namespace BoldApps\ShopifyToolkit\Models;
 
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
+
 class RefundLineItem
 {
+
+    use HasAttributesTrait;
+
     /** @var int */
     public $id;
 

--- a/src/Models/Script.php
+++ b/src/Models/Script.php
@@ -3,9 +3,13 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class Script implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 

--- a/src/Models/ShippingZone.php
+++ b/src/Models/ShippingZone.php
@@ -3,9 +3,12 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class ShippingZone implements Serializeable
 {
+
+    use HasAttributesTrait;
 
     /**
      * @var int

--- a/src/Models/Shop.php
+++ b/src/Models/Shop.php
@@ -3,12 +3,16 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 /**
  * Class Shop.
  */
 class Shop implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var string */
     protected $myshopifyDomain;
 

--- a/src/Models/SmartCollection.php
+++ b/src/Models/SmartCollection.php
@@ -4,10 +4,14 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 use Illuminate\Support\Collection;
 
 class SmartCollection implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 

--- a/src/Models/SmartCollectionRule.php
+++ b/src/Models/SmartCollectionRule.php
@@ -3,9 +3,13 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class SmartCollectionRule implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var string */
     protected $column;
 

--- a/src/Models/TaxLine.php
+++ b/src/Models/TaxLine.php
@@ -3,12 +3,15 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 /**
  * Class TaxLine.
  */
 class TaxLine implements Serializeable
 {
+
+    use HasAttributesTrait;
 
     /** @var  string */
     protected $title;

--- a/src/Models/Theme.php
+++ b/src/Models/Theme.php
@@ -3,9 +3,13 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class Theme implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var  int */
     protected $id;
 
@@ -152,6 +156,7 @@ class Theme implements Serializeable
     {
         return $this->previewable;
     }
+
     /**
      * @return bool
      */

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -4,9 +4,13 @@ namespace BoldApps\ShopifyToolkit\Models;
 
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class Transaction implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var int */
     public $id;
 

--- a/src/Models/UsageCharge.php
+++ b/src/Models/UsageCharge.php
@@ -3,6 +3,7 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 /**
  * Class UsageCharge
@@ -10,6 +11,8 @@ use BoldApps\ShopifyToolkit\Contracts\Serializeable;
  */
 class UsageCharge implements Serializeable
 {
+
+    use HasAttributesTrait;
 
     /**
      * @var int

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -4,10 +4,14 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 
 class User implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 

--- a/src/Models/Variant.php
+++ b/src/Models/Variant.php
@@ -3,12 +3,16 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 /**
  * Class Variant
  */
 class Variant implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var  string */
     protected $id;
 

--- a/src/Models/Webhook.php
+++ b/src/Models/Webhook.php
@@ -3,9 +3,13 @@
 namespace BoldApps\ShopifyToolkit\Models;
 
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class Webhook implements Serializeable
 {
+
+    use HasAttributesTrait;
+
     /** @var int */
     protected $id;
 

--- a/src/Traits/HasAttributesTrait.php
+++ b/src/Traits/HasAttributesTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BoldApps\ShopifyToolkit\Traits;
+
+use Illuminate\Support\Str;
+
+/**
+ * Trait HasAttributesTrait
+ *
+ * Based off of HasAttributes from Eloquent:
+ * https://github.com/laravel/framework/blob/16983a689d15333e7101457c3e0c0d0b7da01d69/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+ * @package BoldApps\ShopifyToolkit\Traits
+ */
+trait HasAttributesTrait
+{
+
+    public function __get($name)
+    {
+        if ($this->hasGetMutator($name)) {
+            return $this->{'get'.Str::studly($name)}();
+        }
+    }
+
+    public function __isset($name)
+    {
+        return ($this->hasGetMutator($name) && $this->{'get'.Str::studly($name)}() !== null);
+    }
+
+    public function hasGetMutator($name)
+    {
+        if (!$name) {
+            return false;
+        }
+
+        return method_exists($this, 'get'.Str::studly($name));
+    }
+
+}

--- a/tests/Traits/HasAttributesTraitTest.php
+++ b/tests/Traits/HasAttributesTraitTest.php
@@ -1,0 +1,58 @@
+<?php
+
+
+class HasAttributesTraitTest extends \PHPUnit\Framework\TestCase
+{
+
+    /** @var \BoldApps\ShopifyToolkit\Models\Customer */
+    private $customerObject;
+
+    /**
+     *
+     */
+    protected function setUp()
+    {
+        $this->customerObject = new \BoldApps\ShopifyToolkit\Models\Customer();
+    }
+
+    public function testHasAttribute()
+    {
+        $firstName = 'cool first name';
+        $this->customerObject->setFirstName($firstName);
+        $this->assertEquals($firstName, $this->customerObject->first_name);
+        $this->assertEquals($firstName, $this->customerObject->firstName);
+        $this->assertEquals($this->customerObject->getFirstName(), $this->customerObject->first_name);
+        $this->assertEquals($this->customerObject->getFirstName(), $this->customerObject->firstName);
+    }
+
+    public function testHasAttributeFails()
+    {
+        $this->assertNull($this->customerObject->yesnt_exists);
+        $this->assertNull($this->customerObject->yesntExists);
+    }
+
+    public function testHasMutator()
+    {
+        $this->assertTrue($this->customerObject->hasGetMutator('first_name'));
+        $this->assertTrue($this->customerObject->hasGetMutator('firstName'));
+    }
+
+    public function testHasMutatorFails()
+    {
+        $this->assertFalse($this->customerObject->hasGetMutator('yesnt_exists'));
+        $this->assertFalse($this->customerObject->hasGetMutator('yesntExists'));
+    }
+
+    public function testIsset()
+    {
+        $firstName = 'cool first name';
+        $this->customerObject->setFirstName($firstName);
+        $this->assertTrue(isset($this->customerObject->first_name));
+    }
+
+    public function testIssetFails()
+    {
+        $this->assertFalse(isset($this->customerObject->first_name));
+    }
+
+}


### PR DESCRIPTION
- I was running into a problem using Eloquent helper functions on these
models (pluck, filter, etc) and doing this will allow those functions to
work properly.
- General cleanup and formatting on all model files while I was in
there.
- Fixed a missing return statement
- Added a test for my trait.
- Removed scalar type hints to maintain php 5.6 compatibility.