### PR TITLE
Add Laravel 5.6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "5.2.* || 5.3.* || 5.4.* || 5.5.*",
+        "illuminate/support": "5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.*",
         "guzzlehttp/guzzle": "^6.2"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba8f34c11992bd1a88c5a5d6efa3a5a3",
+    "content-hash": "85c694c9c37d3a23cdd70a5ec7d9bcfb",
     "packages": [
         {
             "name": "doctrine/inflector",


### PR DESCRIPTION
- I ran the unit tests with illuminate/support:5.6 and all of the tests pass.
- I tried to include this branch from a laravel 5.6 project and it worked.