### PR TITLE
Add support for creating test orders

### DIFF
--- a/src/Services/Client.php
+++ b/src/Services/Client.php
@@ -106,9 +106,10 @@ class Client
      *
      * @return array
      */
-    public function post($path, $params, $body, array $cookies = [], $password = null, $frontendApi = false)
+    public function post($path, $params, $body, array $cookies = [], $password = null, $frontendApi = false, $extraHeaders = [])
     {
         $headers = ['X-Shopify-Access-Token' => $this->shopAccessInfo->getToken(), 'Content-Type' => 'application/json', 'charset' => 'utf-8'];
+        $headers = array_merge($headers, $extraHeaders);
 
         $domain = $frontendApi ? $this->shopBaseInfo->getDomain() : $this->shopBaseInfo->getMyShopifyDomain();
 

--- a/src/Services/Order.php
+++ b/src/Services/Order.php
@@ -141,6 +141,22 @@ class Order extends CollectionEntity
     }
 
     /**
+     * @param ShopifyOrder $order
+     *
+     * @return ShopifyOrder | object
+     */
+    public function createTest($order)
+    {
+        $order->setTest(true);
+
+        $serializedModel = ['order' => $this->serializeModel($order)];
+
+        $raw = $this->client->post('admin/orders.json', [], $serializedModel, [], null, false, ['X-Shopify-Api-Features' => 'creates-test-orders']);
+
+        return $this->unserializeModel($raw['order'], ShopifyOrder::class);
+    }
+
+    /**
      * @param $entities
      *
      * @return array|null

--- a/tests/Services/ClientTest.php
+++ b/tests/Services/ClientTest.php
@@ -11,6 +11,8 @@ use BoldApps\ShopifyToolkit\Services\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockBuilder as Mock;
@@ -58,8 +60,10 @@ class ClientTest extends TestCase
             ->method('getMyShopifyDomain')
             ->will($this->returnValue($this->myShopifyDomain));
 
-        $this->client = new Client($this->mockShopBaseInfo, $this->mockShopAccessInfo, $mockHttpClient,
-            $this->mockRequestHookInterface);
+        $this->client = new Client(
+            $this->mockShopBaseInfo, $this->mockShopAccessInfo, $mockHttpClient,
+            $this->mockRequestHookInterface
+        );
 
         for ($i = 0; $i < $times; ++$i) {
             $raw = $this->client->get('admin/orders/1.json');
@@ -79,17 +83,19 @@ class ClientTest extends TestCase
 
         $this->expectException(TooManyRequestsException::class);
 
-        $this->client = new Client($this->mockShopBaseInfo, $this->mockShopAccessInfo, $mockHttpClient,
-            $this->mockRequestHookInterface);
+        $this->client = new Client(
+            $this->mockShopBaseInfo, $this->mockShopAccessInfo, $mockHttpClient,
+            $this->mockRequestHookInterface
+        );
 
         $this->client->get('admin/orders/1.json');
     }
 
     /**
      * @param null|string $expected
-     * @param int         $responseCode
-     * @param array       $responseHeader
-     * @param mixed       $exceptionClass
+     * @param int $responseCode
+     * @param array $responseHeader
+     * @param mixed $exceptionClass
      *
      * @dataProvider getRedirectLocationProvider
      */
@@ -107,11 +113,79 @@ class ClientTest extends TestCase
             $this->expectException($exceptionClass);
         }
 
-        $this->client = new Client($this->mockShopBaseInfo, $this->mockShopAccessInfo, $mockHttpClient,
-            $this->mockRequestHookInterface);
+        $this->client = new Client(
+            $this->mockShopBaseInfo, $this->mockShopAccessInfo, $mockHttpClient,
+            $this->mockRequestHookInterface
+        );
 
         $result = $this->client->getRedirectLocation('admin/discount_codes/lookup.json', ['code' => 'DISCOUNT_CODE']);
         $this->assertSame($expected, $result);
+    }
+
+    public function testClientWillApplyPostHeadersProperly()
+    {
+        $expectedHeaders = [
+            'Content-Length' =>
+                [
+                    0 => '4',
+                ],
+            'Host' =>
+                [
+                    0 => 'fight-club.myshopify.com',
+                ],
+            'X-Shopify-Access-Token' =>
+                [
+                    0 => '',
+                ],
+            'Content-Type' =>
+                [
+                    0 => 'application/json',
+                ],
+            'charset' =>
+                [
+                    0 => 'utf-8',
+                ],
+            'X-Shopify-Api-Features' =>
+                [
+                    0 => 'creates-test-orders',
+                ],
+        ];
+
+        // mock http client
+        $mock = new MockHandler([new Response(200)]);
+        $container = [];
+        $history = Middleware::history($container);
+        $handlerStack = HandlerStack::create($mock);
+        // Add the history middleware to the handler stack.
+        $handlerStack->push($history);
+        $mockHttpClient = new \GuzzleHttp\Client(['handler' => $handlerStack]);
+
+        $this->mockShopBaseInfo->expects($this->any())
+            ->method('getMyShopifyDomain')
+            ->will($this->returnValue($this->myShopifyDomain));
+
+        $this->client = new Client(
+            $this->mockShopBaseInfo, $this->mockShopAccessInfo, $mockHttpClient,
+            $this->mockRequestHookInterface
+        );
+
+        $raw = $this->client->post(
+            'admin/orders.json',
+            [],
+            '{}',
+            [],
+            null,
+            false,
+            ['X-Shopify-Api-Features' => 'creates-test-orders']
+        );
+
+        /* @var Request $sentRequest */
+        $sentRequest = $container[0]['request'];
+        $sentHeaders = $sentRequest->getHeaders();
+        //User agent varies per system.
+        unset($sentHeaders['User-Agent']);
+
+        $this->assertEquals($expectedHeaders, $sentHeaders);
     }
 
     public static function getRedirectLocationProvider()
@@ -120,15 +194,51 @@ class ClientTest extends TestCase
         $adminURI = 'admin/price_rules/294645137513/discount_codes/1318545293417';
 
         return [
-            ['expected' => null, 'responseCode' => 404, 'responseHeader' => [], 'exceptionClass' => NotFoundException::class],
-            ['expected' => null, 'responseCode' => 500, 'responseHeader' => [], 'exceptionClass' => RequestException::class],
+            [
+                'expected' => null,
+                'responseCode' => 404,
+                'responseHeader' => [],
+                'exceptionClass' => NotFoundException::class,
+            ],
+            [
+                'expected' => null,
+                'responseCode' => 500,
+                'responseHeader' => [],
+                'exceptionClass' => RequestException::class,
+            ],
             ['expected' => null, 'responseCode' => 200, 'responseHeader' => [], 'exceptionClass' => null],
             ['expected' => null, 'responseCode' => 303, 'responseHeader' => [], 'exceptionClass' => null],
-            ['expected' => null, 'responseCode' => 303, 'responseHeader' => ['Location' => []], 'exceptionClass' => null],
-            ['expected' => null, 'responseCode' => 303, 'responseHeader' => ['Connection' => ['keep-alive']], 'exceptionClass' => null],
-            ['expected' => null, 'responseCode' => 303, 'responseHeader' => ['Location' => ['this/is/not/a/valid/url']], 'exceptionClass' => null],
-            ['expected' => "$adminURI.json", 'responseCode' => 303, 'responseHeader' => ['Location' => ["https://$shopDomain/$adminURI"]], 'exceptionClass' => null],
-            ['expected' => "$adminURI.json", 'responseCode' => 303, 'responseHeader' => ['Location' => ["https://$shopDomain/$adminURI.json"]], 'exceptionClass' => null],
+            [
+                'expected' => null,
+                'responseCode' => 303,
+                'responseHeader' => ['Location' => []],
+                'exceptionClass' => null,
+            ],
+            [
+                'expected' => null,
+                'responseCode' => 303,
+                'responseHeader' => ['Connection' => ['keep-alive']],
+                'exceptionClass' => null,
+            ],
+            [
+                'expected' => null,
+                'responseCode' => 303,
+                'responseHeader' => ['Location' => ['this/is/not/a/valid/url']],
+                'exceptionClass' => null,
+            ],
+            [
+                'expected' => "$adminURI.json",
+                'responseCode' => 303,
+                'responseHeader' => ['Location' => ["https://$shopDomain/$adminURI"]],
+                'exceptionClass' => null,
+            ],
+            [
+                'expected' => "$adminURI.json",
+                'responseCode' => 303,
+                'responseHeader' => ['Location' => ["https://$shopDomain/$adminURI.json"]],
+                'exceptionClass' => null,
+            ],
         ];
     }
+
 }


### PR DESCRIPTION
- As of 2018-08-23 this is a hidden API feature that allows you to
create a test order in your store without hitting the limits set by
shopify for affiliate plan stores.