### PR TITLE
Add new endpoint for SmartCollection API

### DIFF
--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -22,6 +22,9 @@ class Product implements Serializeable
     /** @var string */
     protected $productType;
 
+    /** @var bool */
+    protected $manuallySorted;
+
     /** @var string */
     protected $publishedScope;
 
@@ -123,6 +126,22 @@ class Product implements Serializeable
     public function setProductType($productType)
     {
         $this->productType = $productType;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getManuallySorted()
+    {
+        return $this->manuallySorted;
+    }
+
+    /**
+     * @param bool $manuallySorted
+     */
+    public function setManuallySorted($manuallySorted)
+    {
+        $this->manuallySorted = $manuallySorted;
     }
 
     /**

--- a/src/Services/CustomCollection.php
+++ b/src/Services/CustomCollection.php
@@ -53,13 +53,13 @@ class CustomCollection extends CollectionEntity
     }
 
     /**
-     * @param $parms
+     * @param $params
      *
      * @return \Illuminate\Support\Collection
      */
-    public function getByParams($parms)
+    public function getByParams($params)
     {
-        $raw = $this->client->get('admin/custom_collections.json', $parms);
+        $raw = $this->client->get('admin/custom_collections.json', $params);
 
         $collection = array_map(function ($product) {
             return $this->unserializeModel($product, ShopifyCustomCollection::class);

--- a/src/Services/Customer.php
+++ b/src/Services/Customer.php
@@ -38,13 +38,13 @@ class Customer extends CollectionEntity
     }
 
     /**
-     * @param array $parms
+     * @param array $params
      *
      * @return Collection
      */
-    public function getByParams($parms)
+    public function getByParams($params)
     {
-        $raw = $this->client->get('admin/customers.json', $parms);
+        $raw = $this->client->get('admin/customers.json', $params);
 
         $customers = array_map(function ($customer) {
             return $this->unserializeModel($customer, ShopifyCustomer::class);

--- a/src/Services/Image.php
+++ b/src/Services/Image.php
@@ -26,7 +26,7 @@ class Image extends Base
     /**
      * @param $array
      *
-     * @return object
+     * @return ShopifyImage | object
      */
     public function createFromArray($array)
     {

--- a/src/Services/Metafield.php
+++ b/src/Services/Metafield.php
@@ -2,17 +2,17 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
-use BoldApps\ShopifyToolkit\Models\Metafield as MetafieldModel;
+use BoldApps\ShopifyToolkit\Models\Metafield as ShopifyMetafield;
 
 class Metafield extends Base
 {
     /**
-     * @param $array
+     * @param array $array
      *
-     * @return MetafieldModel | object
+     * @return ShopifyMetafield | object
      */
     public function createFromArray($array)
     {
-        return $this->unserializeModel($array, MetafieldModel::class);
+        return $this->unserializeModel($array, ShopifyMetafield::class);
     }
 }

--- a/src/Services/Option.php
+++ b/src/Services/Option.php
@@ -2,6 +2,17 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Models\Option as ShopifyOption;
+
 class Option extends Base
 {
+    /**
+     * @param array $array
+     *
+     * @return ShopifyOption | object
+     */
+    public function createFromArray($array)
+    {
+        return $this->unserializeModel($array, ShopifyOption::class);
+    }
 }

--- a/src/Services/Order.php
+++ b/src/Services/Order.php
@@ -73,13 +73,13 @@ class Order extends CollectionEntity
     }
 
     /**
-     * @param $parms
+     * @param $params
      *
      * @return Collection
      */
-    public function getByParams($parms)
+    public function getByParams($params)
     {
-        $raw = $this->client->get('admin/orders.json', $parms);
+        $raw = $this->client->get('admin/orders.json', $params);
 
         $orders = array_map(function ($order) {
             return $this->unserializeModel($order, ShopifyOrder::class);

--- a/src/Services/Product.php
+++ b/src/Services/Product.php
@@ -2,17 +2,16 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Models\Image as ShopifyImage;
 use BoldApps\ShopifyToolkit\Models\Metafield as ShopifyMetafield;
+use BoldApps\ShopifyToolkit\Models\Option as ShopifyOption;
 use BoldApps\ShopifyToolkit\Models\Product as ShopifyProduct;
-use BoldApps\ShopifyToolkit\Models\Product as ProductModel;
-use BoldApps\ShopifyToolkit\Models\Variant as VariantModel;
-use BoldApps\ShopifyToolkit\Models\Option as OptionModel;
-use BoldApps\ShopifyToolkit\Models\Image as ImageModel;
+use BoldApps\ShopifyToolkit\Models\Variant as ShopifyVariant;
 use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
-use BoldApps\ShopifyToolkit\Services\Variant as VariantService;
-use BoldApps\ShopifyToolkit\Services\Option as OptionService;
 use BoldApps\ShopifyToolkit\Services\Image as ImageService;
 use BoldApps\ShopifyToolkit\Services\Metafield as MetafieldService;
+use BoldApps\ShopifyToolkit\Services\Option as OptionService;
+use BoldApps\ShopifyToolkit\Services\Variant as VariantService;
 use Illuminate\Support\Collection;
 
 class Product extends CollectionEntity
@@ -86,10 +85,10 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param $id
-     * @param $filter
+     * @param       $id
+     * @param array $filter
      *
-     * @return ShopifyProduct
+     * @return ShopifyProduct | object
      */
     public function getById($id, $filter = [])
     {
@@ -117,13 +116,13 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param $parms
+     * @param array $params
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
-    public function getByParams($parms)
+    public function getByParams($params)
     {
-        $raw = $this->client->get('admin/products.json', $parms);
+        $raw = $this->client->get('admin/products.json', $params);
 
         $products = array_map(function ($product) {
             return $this->unserializeModel($product, ShopifyProduct::class);
@@ -133,7 +132,7 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param $productIds
+     * @param array $productIds
      * @param array $filter
      *
      * @return Collection
@@ -182,7 +181,7 @@ class Product extends CollectionEntity
     /**
      * @param ShopifyProduct $product
      *
-     * @return object
+     * @return array | null
      */
     public function delete(ShopifyProduct $product)
     {
@@ -202,31 +201,20 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param $filter
-     *
-     * @return int
-     */
-    public function countByParams($filter = [])
-    {
-        $raw = $this->client->get('admin/products/count.json', $filter);
-
-        return $raw['count'];
-    }
-
-    /**
-     * @param $array
+     * @param array $array
      *
      * @return object
      */
     public function createFromArray($array)
     {
-        return $this->unserializeModel($array, ProductModel::class);
+        return $this->unserializeModel($array, ShopifyProduct::class);
     }
 
     /**
-     * @param ShopifyProduct $product
+     * @param ShopifyProduct   $product
+     * @param ShopifyMetafield $metafield
      *
-     * @return Collection
+     * @return ShopifyMetafield | object
      */
     public function createOrUpdateMetafield(ShopifyProduct $product, ShopifyMetafield $metafield)
     {
@@ -239,7 +227,7 @@ class Product extends CollectionEntity
 
     /**
      * @param ShopifyProduct $product
-     * @param $filter
+     * @param array          $filter
      *
      * @return Collection
      */
@@ -255,9 +243,10 @@ class Product extends CollectionEntity
     }
 
     /**
+     * @param                $id
      * @param ShopifyProduct $product
      *
-     * @return Collection
+     * @return ShopifyMetafield | object
      */
     public function getMetafield(ShopifyProduct $product, $id)
     {
@@ -267,9 +256,10 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param ShopifyProduct $product
+     * @param ShopifyProduct   $product
+     * @param ShopifyMetafield $metafield
      *
-     * @return Collection
+     * @return array | null
      */
     public function deleteMetafield(ShopifyProduct $product, ShopifyMetafield $metafield)
     {
@@ -278,28 +268,28 @@ class Product extends CollectionEntity
 
     /**
      * @param int $metafieldId
+     *
+     * @return array | null
      */
     public function deleteMetafieldById($metafieldId)
     {
-        $this->client->delete("admin/metafields/{$metafieldId}.json");
+        return $this->client->delete("admin/metafields/{$metafieldId}.json");
     }
 
     /**
      * @param $entities
      *
-     * @return array|null
+     * @return array | null
      */
     protected function serializeVariants($entities)
     {
         if (null === $entities) {
-            return;
+            return null;
         }
 
-        $variantService = &$this->variantService;
-
         if ($entities instanceof Collection) {
-            return $entities->map(function ($entity) use ($variantService) {
-                return $variantService->serializeModel($entity);
+            return $entities->map(function ($entity) {
+                return $this->variantService->serializeModel($entity);
             })->toArray();
         }
 
@@ -309,18 +299,16 @@ class Product extends CollectionEntity
     /**
      * @param array $data
      *
-     * @return Collection
+     * @return Collection | null
      */
     protected function unserializeVariants($data)
     {
         if (null === $data) {
-            return;
+            return null;
         }
 
-        $variantService = &$this->variantService;
-
-        $variants = array_map(function ($variant) use ($variantService) {
-            return $variantService->unserializeModel($variant, VariantModel::class);
+        $variants = array_map(function ($variant) {
+            return $this->variantService->unserializeModel($variant, ShopifyVariant::class);
         }, $data);
 
         return new Collection($variants);
@@ -329,19 +317,17 @@ class Product extends CollectionEntity
     /**
      * @param $entities
      *
-     * @return array|null
+     * @return array | null
      */
     protected function serializeOptions($entities)
     {
         if (null === $entities) {
-            return;
+            return null;
         }
 
-        $optionService = &$this->optionService;
-
         if ($entities instanceof Collection) {
-            return $entities->map(function ($entity) use ($optionService) {
-                return $optionService->serializeModel($entity);
+            return $entities->map(function ($entity) {
+                return $this->optionService->serializeModel($entity);
             })->toArray();
         }
 
@@ -351,18 +337,16 @@ class Product extends CollectionEntity
     /**
      * @param array $data
      *
-     * @return Collection
+     * @return Collection | null
      */
     protected function unserializeOptions($data)
     {
         if (null === $data) {
-            return;
+            return null;
         }
 
-        $optionService = &$this->optionService;
-
-        $options = array_map(function ($option) use ($optionService) {
-            return $optionService->unserializeModel($option, OptionModel::class);
+        $options = array_map(function ($option) {
+            return $this->optionService->unserializeModel($option, ShopifyOption::class);
         }, $data);
 
         return new Collection($options);
@@ -371,47 +355,45 @@ class Product extends CollectionEntity
     /**
      * @param $entity
      *
-     * @return array|null
+     * @return array | null
      */
     protected function serializeImage($entity)
     {
         if (null === $entity) {
-            return;
+            return null;
         }
 
-        return $this->optionService->serializeModel($entity);
+        return $this->imageService->serializeModel($entity);
     }
 
     /**
      * @param array $data
      *
-     * @return object
+     * @return ShopifyImage | object
      */
     protected function unserializeImage($data)
     {
         if (null === $data) {
-            return;
+            return null;
         }
 
-        return $this->imageService->unserializeModel($data, ImageModel::class);
+        return $this->imageService->unserializeModel($data, ShopifyImage::class);
     }
 
     /**
      * @param $entities
      *
-     * @return array|null
+     * @return array | null
      */
     protected function serializeImages($entities)
     {
         if (null === $entities) {
-            return;
+            return null;
         }
 
-        $imageService = &$this->imageService;
-
         if ($entities instanceof Collection) {
-            return $entities->map(function ($entity) use ($imageService) {
-                return $imageService->serializeModel($entity);
+            return $entities->map(function ($entity) {
+                return $this->imageService->serializeModel($entity);
             })->toArray();
         }
 
@@ -421,18 +403,16 @@ class Product extends CollectionEntity
     /**
      * @param array $data
      *
-     * @return Collection
+     * @return Collection | null
      */
     protected function unserializeImages($data)
     {
         if (null === $data) {
-            return;
+            return null;
         }
 
-        $imageService = &$this->imageService;
-
-        $images = array_map(function ($image) use ($imageService) {
-            return $imageService->unserializeModel($image, ImageModel::class);
+        $images = array_map(function ($image) {
+            return $this->imageService->unserializeModel($image, ShopifyImage::class);
         }, $data);
 
         return new Collection($images);
@@ -440,11 +420,13 @@ class Product extends CollectionEntity
 
     /**
      * @param $entities
+     *
+     * @return array | null
      */
     protected function serializeMetafields($entities)
     {
         if (null === $entities) {
-            return;
+            return null;
         }
 
         if ($entities instanceof Collection) {
@@ -452,17 +434,19 @@ class Product extends CollectionEntity
                 return $this->metafieldService->serializeModel($entity);
             })->toArray();
         }
+
+        return $entities;
     }
 
     /**
      * @param $data
      *
-     * @return Collection|void
+     * @return Collection | null
      */
     protected function unserializeMetafields($data)
     {
         if (null === $data) {
-            return;
+            return null;
         }
 
         $metafields = array_map(function ($metafield) {

--- a/src/Services/SmartCollection.php
+++ b/src/Services/SmartCollection.php
@@ -6,6 +6,7 @@ use BoldApps\ShopifyToolkit\Models\SmartCollectionRule as ShopifySmartCollection
 use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
 use BoldApps\ShopifyToolkit\Models\SmartCollection as ShopifySmartCollection;
 use BoldApps\ShopifyToolkit\Services\SmartCollectionRule as SmartCollectionRuleService;
+use BoldApps\ShopifyToolkit\Models\Product as ShopifyProduct;
 use Illuminate\Support\Collection;
 
 class SmartCollection extends CollectionEntity
@@ -81,6 +82,23 @@ class SmartCollection extends CollectionEntity
     }
 
     /**
+     * @param int   $id
+     * @param array $filter
+     *
+     * @return Collection
+     */
+    public function getProductsBySmartCollectionId($id, $filter = [])
+    {
+        $raw = $this->client->get("admin/smart_collections/$id/products.json", $filter);
+
+        $products = array_map(function ($product) {
+            return $this->unserializeModel($product, ShopifyProduct::class);
+        }, $raw['products']);
+
+        return new Collection($products);
+    }
+
+    /**
      * @param int   $page
      * @param int   $limit
      * @param array $filter
@@ -100,13 +118,13 @@ class SmartCollection extends CollectionEntity
     }
 
     /**
-     * @param $parms
+     * @param $params
      *
      * @return \Illuminate\Support\Collection
      */
-    public function getByParams($parms)
+    public function getByParams($params)
     {
-        $raw = $this->client->get('admin/smart_collections.json', $parms);
+        $raw = $this->client->get('admin/smart_collections.json', $params);
 
         $collection = array_map(function ($product) {
             return $this->unserializeModel($product, ShopifySmartCollection::class);

--- a/src/Services/Variant.php
+++ b/src/Services/Variant.php
@@ -25,7 +25,7 @@ class Variant extends Base
     }
 
     /**
-     * @param $array
+     * @param array $array
      *
      * @return object
      */

--- a/tests/ProductTest.php
+++ b/tests/ProductTest.php
@@ -1,0 +1,445 @@
+<?php
+
+use BoldApps\ShopifyToolkit\Models\Product as ShopifyProduct;
+use BoldApps\ShopifyToolkit\Services\Client;
+use BoldApps\ShopifyToolkit\Services\Image as ImageService;
+use BoldApps\ShopifyToolkit\Services\Metafield as MetafieldService;
+use BoldApps\ShopifyToolkit\Services\Option as OptionService;
+use BoldApps\ShopifyToolkit\Services\Product as ProductService;
+use BoldApps\ShopifyToolkit\Services\Variant as VariantService;
+
+class ProductTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var ProductService */
+    private $productService;
+
+    /** @var VariantService */
+    private $variantService;
+
+    /** @var OptionService */
+    private $optionService;
+
+    /** @var ImageService */
+    private $imageService;
+
+    /** @var MetafieldService */
+    private $metafieldService;
+
+    protected function setUp()
+    {
+        /** @var Client $client */
+        $client = $this->createMock(Client::class);
+
+        $this->variantService = new VariantService($client);
+        $this->optionService = new OptionService($client);
+        $this->imageService = new ImageService($client);
+        $this->metafieldService = new MetafieldService($client);
+
+        $this->productService = new ProductService(
+            $client,
+            $this->variantService,
+            $this->optionService,
+            $this->imageService,
+            $this->metafieldService
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyProductSerializesProperly()
+    {
+        /** @var ShopifyProduct $productEntity */
+        $productEntity = $this->productService->createFromArray($this->getProductArray());
+
+        $expected = $this->getProductArray();
+        $actual = $this->productService->serializeModel($productEntity);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function ShopifyProductDeserializesProperly()
+    {
+        $productJson = $this->getProductJson();
+        $jsonArray = (array) json_decode($productJson, true);
+
+        $expected = $this->productService->createFromArray($this->getProductArray());
+        $actual = $this->productService->unserializeModel($jsonArray, ShopifyProduct::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    private function getProductJson()
+    {
+        return '{
+            "id": 632910392,
+            "title": "IPod Nano - 8GB",
+            "body_html": "<p>It\'s the small iPod with one very big idea: Video. Now the world\'s most popular music player, available in 4GB and 8GB models, lets you enjoy TV shows, movies, video podcasts, and more. The larger, brighter display means amazing picture quality. In six eye-catching colors, iPod nano is stunning all around. And with models starting at just $149, little speaks volumes.</p>",
+            "vendor": "Apple",
+            "product_type": "Cult Products",
+            "created_at": "2018-09-25T15:15:37-04:00",
+            "handle": "ipod-nano",
+            "updated_at": "2018-09-25T15:15:37-04:00",
+            "published_at": "2007-12-31T19:00:00-05:00",
+            "template_suffix": null,
+            "tags": "Emotive, Flash Memory, MP3, Music",
+            "published_scope": "web",
+            "manually_sorted": "true",
+            "admin_graphql_api_id": "gid://shopify/Product/632910392",
+            "variants": [
+                {
+                    "id": 808950810,
+                    "product_id": 632910392,
+                    "title": "Pink",
+                    "price": "199.00",
+                    "sku": "IPOD2008PINK",
+                    "position": 1,
+                    "inventory_policy": "continue",
+                    "compare_at_price": null,
+                    "fulfillment_service": "manual",
+                    "inventory_management": "shopify",
+                    "option1": "Pink",
+                    "option2": null,
+                    "option3": null,
+                    "created_at": "2018-09-25T15:15:37-04:00",
+                    "updated_at": "2018-09-25T15:15:37-04:00",
+                    "taxable": true,
+                    "barcode": "1234_pink",
+                    "grams": 567,
+                    "image_id": 562641783,
+                    "inventory_quantity": 10,
+                    "weight": 1.25,
+                    "weight_unit": "lb",
+                    "inventory_item_id": 808950810,
+                    "old_inventory_quantity": 10,
+                    "requires_shipping": true,
+                    "admin_graphql_api_id": "gid://shopify/ProductVariant/808950810"
+                },
+                {
+                    "id": 49148385,
+                    "product_id": 632910392,
+                    "title": "Red",
+                    "price": "199.00",
+                    "sku": "IPOD2008RED",
+                    "position": 2,
+                    "inventory_policy": "continue",
+                    "compare_at_price": null,
+                    "fulfillment_service": "manual",
+                    "inventory_management": "shopify",
+                    "option1": "Red",
+                    "option2": null,
+                    "option3": null,
+                    "created_at": "2018-09-25T15:15:37-04:00",
+                    "updated_at": "2018-09-25T15:15:37-04:00",
+                    "taxable": true,
+                    "barcode": "1234_red",
+                    "grams": 567,
+                    "image_id": null,
+                    "inventory_quantity": 20,
+                    "weight": 1.25,
+                    "weight_unit": "lb",
+                    "inventory_item_id": 49148385,
+                    "old_inventory_quantity": 20,
+                    "requires_shipping": true,
+                    "admin_graphql_api_id": "gid://shopify/ProductVariant/49148385"
+                },
+                {
+                    "id": 39072856,
+                    "product_id": 632910392,
+                    "title": "Green",
+                    "price": "199.00",
+                    "sku": "IPOD2008GREEN",
+                    "position": 3,
+                    "inventory_policy": "continue",
+                    "compare_at_price": null,
+                    "fulfillment_service": "manual",
+                    "inventory_management": "shopify",
+                    "option1": "Green",
+                    "option2": null,
+                    "option3": null,
+                    "created_at": "2018-09-25T15:15:37-04:00",
+                    "updated_at": "2018-09-25T15:15:37-04:00",
+                    "taxable": true,
+                    "barcode": "1234_green",
+                    "grams": 567,
+                    "image_id": null,
+                    "inventory_quantity": 30,
+                    "weight": 1.25,
+                    "weight_unit": "lb",
+                    "inventory_item_id": 39072856,
+                    "old_inventory_quantity": 30,
+                    "requires_shipping": true,
+                    "admin_graphql_api_id": "gid://shopify/ProductVariant/39072856"
+                },
+                {
+                    "id": 457924702,
+                    "product_id": 632910392,
+                    "title": "Black",
+                    "price": "199.00",
+                    "sku": "IPOD2008BLACK",
+                    "position": 4,
+                    "inventory_policy": "continue",
+                    "compare_at_price": null,
+                    "fulfillment_service": "manual",
+                    "inventory_management": "shopify",
+                    "option1": "Black",
+                    "option2": null,
+                    "option3": null,
+                    "created_at": "2018-09-25T15:15:37-04:00",
+                    "updated_at": "2018-09-25T15:15:37-04:00",
+                    "taxable": true,
+                    "barcode": "1234_black",
+                    "grams": 567,
+                    "image_id": null,
+                    "inventory_quantity": 40,
+                    "weight": 1.25,
+                    "weight_unit": "lb",
+                    "inventory_item_id": 457924702,
+                    "old_inventory_quantity": 40,
+                    "requires_shipping": true,
+                    "admin_graphql_api_id": "gid://shopify/ProductVariant/457924702"
+                }
+            ],
+            "options": [
+                {
+                    "id": 594680422,
+                    "product_id": 632910392,
+                    "name": "Color",
+                    "position": 1,
+                    "values": [
+                        "Pink",
+                        "Red",
+                        "Green",
+                        "Black"
+                    ]
+                }
+            ],
+            "images": [
+                {
+                    "id": 850703190,
+                    "product_id": 632910392,
+                    "position": 1,
+                    "created_at": "2018-09-25T15:15:37-04:00",
+                    "updated_at": "2018-09-25T15:15:37-04:00",
+                    "alt": null,
+                    "width": 123,
+                    "height": 456,
+                    "src": "https://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano.png?v=1537902937",
+                    "variant_ids": [],
+                    "admin_graphql_api_id": "gid://shopify/ProductImage/850703190"
+                },
+                {
+                    "id": 562641783,
+                    "product_id": 632910392,
+                    "position": 2,
+                    "created_at": "2018-09-25T15:15:37-04:00",
+                    "updated_at": "2018-09-25T15:15:37-04:00",
+                    "alt": null,
+                    "width": 123,
+                    "height": 456,
+                    "src": "https://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano-2.png?v=1537902937",
+                    "variant_ids": [
+                        808950810
+                    ],
+                    "admin_graphql_api_id": "gid://shopify/ProductImage/562641783"
+                }
+            ],
+            "image": {
+                "id": 850703190,
+                "product_id": 632910392,
+                "position": 1,
+                "created_at": "2018-09-25T15:15:37-04:00",
+                "updated_at": "2018-09-25T15:15:37-04:00",
+                "alt": null,
+                "width": 123,
+                "height": 456,
+                "src": "https://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano.png?v=1537902937",
+                "variant_ids": [],
+                "admin_graphql_api_id": "gid://shopify/ProductImage/850703190"
+            },
+            "metafields": [
+                {
+                    "key": "new",
+                    "value": "newvalue",
+                    "value_type": "string",
+                    "namespace": "global"
+                }
+            ]
+        }';
+    }
+
+    private function getProductArray()
+    {
+        return [
+            'id' => 632910392,
+            'title' => 'IPod Nano - 8GB',
+            'body_html' => "<p>It's the small iPod with one very big idea: Video. Now the world's most popular music player, available in 4GB and 8GB models, lets you enjoy TV shows, movies, video podcasts, and more. The larger, brighter display means amazing picture quality. In six eye-catching colors, iPod nano is stunning all around. And with models starting at just $149, little speaks volumes.</p>",
+            'vendor' => 'Apple',
+            'product_type' => 'Cult Products',
+            'created_at' => '2018-09-25T15:15:37-04:00',
+            'handle' => 'ipod-nano',
+            'updated_at' => '2018-09-25T15:15:37-04:00',
+            'published_at' => '2007-12-31T19:00:00-05:00',
+            'tags' => 'Emotive, Flash Memory, MP3, Music',
+            'published_scope' => 'web',
+            'manually_sorted' => 'true',
+            'variants' => [
+                [
+                    'id' => 808950810,
+                    'product_id' => 632910392,
+                    'title' => 'Pink',
+                    'price' => '199.00',
+                    'sku' => 'IPOD2008PINK',
+                    'position' => 1,
+                    'inventory_policy' => 'continue',
+                    'fulfillment_service' => 'manual',
+                    'inventory_management' => 'shopify',
+                    'option1' => 'Pink',
+                    'created_at' => '2018-09-25T15:15:37-04:00',
+                    'updated_at' => '2018-09-25T15:15:37-04:00',
+                    'taxable' => true,
+                    'barcode' => '1234_pink',
+                    'grams' => 567,
+                    'image_id' => 562641783,
+                    'inventory_quantity' => 10,
+                    'weight' => 1.25,
+                    'weight_unit' => 'lb',
+                    'inventory_item_id' => 808950810,
+                    'old_inventory_quantity' => 10,
+                    'requires_shipping' => true,
+                ],
+                [
+                    'id' => 49148385,
+                    'product_id' => 632910392,
+                    'title' => 'Red',
+                    'price' => '199.00',
+                    'sku' => 'IPOD2008RED',
+                    'position' => 2,
+                    'inventory_policy' => 'continue',
+                    'fulfillment_service' => 'manual',
+                    'inventory_management' => 'shopify',
+                    'option1' => 'Red',
+                    'created_at' => '2018-09-25T15:15:37-04:00',
+                    'updated_at' => '2018-09-25T15:15:37-04:00',
+                    'taxable' => true,
+                    'barcode' => '1234_red',
+                    'grams' => 567,
+                    'inventory_quantity' => 20,
+                    'weight' => 1.25,
+                    'weight_unit' => 'lb',
+                    'inventory_item_id' => 49148385,
+                    'old_inventory_quantity' => 20,
+                    'requires_shipping' => true,
+                ],
+                [
+                    'id' => 39072856,
+                    'product_id' => 632910392,
+                    'title' => 'Green',
+                    'price' => '199.00',
+                    'sku' => 'IPOD2008GREEN',
+                    'position' => 3,
+                    'inventory_policy' => 'continue',
+                    'fulfillment_service' => 'manual',
+                    'inventory_management' => 'shopify',
+                    'option1' => 'Green',
+                    'created_at' => '2018-09-25T15:15:37-04:00',
+                    'updated_at' => '2018-09-25T15:15:37-04:00',
+                    'taxable' => true,
+                    'barcode' => '1234_green',
+                    'grams' => 567,
+                    'inventory_quantity' => 30,
+                    'weight' => 1.25,
+                    'weight_unit' => 'lb',
+                    'inventory_item_id' => 39072856,
+                    'old_inventory_quantity' => 30,
+                    'requires_shipping' => true,
+                ],
+                [
+                    'id' => 457924702,
+                    'product_id' => 632910392,
+                    'title' => 'Black',
+                    'price' => '199.00',
+                    'sku' => 'IPOD2008BLACK',
+                    'position' => 4,
+                    'inventory_policy' => 'continue',
+                    'fulfillment_service' => 'manual',
+                    'inventory_management' => 'shopify',
+                    'option1' => 'Black',
+                    'created_at' => '2018-09-25T15:15:37-04:00',
+                    'updated_at' => '2018-09-25T15:15:37-04:00',
+                    'taxable' => true,
+                    'barcode' => '1234_black',
+                    'grams' => 567,
+                    'inventory_quantity' => 40,
+                    'weight' => 1.25,
+                    'weight_unit' => 'lb',
+                    'inventory_item_id' => 457924702,
+                    'old_inventory_quantity' => 40,
+                    'requires_shipping' => true,
+                ],
+            ],
+            'options' => [
+                [
+                    'id' => 594680422,
+                    'product_id' => 632910392,
+                    'name' => 'Color',
+                    'position' => 1,
+                    'values' => [
+                        'Pink',
+                        'Red',
+                        'Green',
+                        'Black',
+                    ],
+                ],
+            ],
+            'images' => [
+                [
+                    'id' => 850703190,
+                    'product_id' => 632910392,
+                    'position' => 1,
+                    'created_at' => '2018-09-25T15:15:37-04:00',
+                    'updated_at' => '2018-09-25T15:15:37-04:00',
+                    'width' => 123,
+                    'height' => 456,
+                    'src' => 'https://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano.png?v=1537902937',
+                    'variant_ids' => [],
+                ],
+                [
+                    'id' => 562641783,
+                    'product_id' => 632910392,
+                    'position' => 2,
+                    'created_at' => '2018-09-25T15:15:37-04:00',
+                    'updated_at' => '2018-09-25T15:15:37-04:00',
+                    'width' => 123,
+                    'height' => 456,
+                    'src' => 'https://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano-2.png?v=1537902937',
+                    'variant_ids' => [
+                        808950810,
+                    ],
+                ],
+            ],
+            'image' => [
+                'id' => 850703190,
+                'product_id' => 632910392,
+                'position' => 1,
+                'created_at' => '2018-09-25T15:15:37-04:00',
+                'updated_at' => '2018-09-25T15:15:37-04:00',
+                'width' => 123,
+                'height' => 456,
+                'src' => 'https://cdn.shopify.com/s/files/1/0006/9093/3842/products/ipod-nano.png?v=1537902937',
+                'variant_ids' => [],
+            ],
+            'metafields' => [
+                [
+                    'key' => 'new',
+                    'value' => 'newvalue',
+                    'value_type' => 'string',
+                    'namespace' => 'global',
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
- Endpoint that [gets all products within a Smart Collection](https://help.shopify.com/en/api/guides/smart-collection-migration-guide#payload-examples)
- New property `manually_sorted` added to Product model for this endpoint
- Added a new test serializing and deserializing a product
- Removing duplicated functions and adding phpdocs to Product service
- Removing need for pointers in serialization/deserialization of Product's child models
- Added `createFromArray` to Option service
- Other small improvements in Product service

### Breaking Change Guide

1. `\BoldApps\ShopifyToolkit\Services\Product::countByParams()` has been removed and usage should be replaced with the function `\BoldApps\ShopifyToolkit\Services\Product::count()` which takes in the same optional parameter `array $filter`. 
2. `\BoldApps\ShopifyToolkit\Services\Product::serializeImage()` was previously using the `Option` service's serialize function so sending product updates that include image changes to Shopify via the API should work.
3. The functions `createOrUpdateMetafield()`, `getMetafield()`, and `deleteMetafield()` previously had the return type `Collection` despite returning a single `Metafield` model so typehints surrounding their results should be updated.