### PR TITLE
Handle null serialize model calls

### DIFF
--- a/src/Services/Base.php
+++ b/src/Services/Base.php
@@ -39,12 +39,16 @@ abstract class Base
     }
 
     /**
-     * @param Serializeable $entity
+     * @param Serializeable|null $entity
      *
      * @return array
      */
-    public function serializeModel(Serializeable $entity)
+    public function serializeModel(Serializeable $entity = null)
     {
+        if (null === $entity) {
+            return null;
+        }
+
         $arr = [];
         $class = new \ReflectionClass($entity);
 
@@ -70,13 +74,21 @@ abstract class Base
     }
 
     /**
-     * @param array $data
+     * @param array|null $data
      * @param $className
      *
      * @return object
      */
-    public function unserializeModel(array $data, $className)
+    public function unserializeModel($data, $className)
     {
+        if (null === $data) {
+            return null;
+        }
+
+        if (!is_array($data)) {
+            throw new \InvalidArgumentException('Invalid argument $data supplied for unserializeModel. Please pass array|null.');
+        }
+
         $class = new \ReflectionClass($className);
 
         $instance = $class->newInstance();

--- a/tests/ShopifyBaseServiceTest.php
+++ b/tests/ShopifyBaseServiceTest.php
@@ -93,4 +93,34 @@ class ShopifyBaseServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($expectedResult == $newArray);
     }
+
+    /** @test */
+    public function unserializeSerializedModelThatIsNull()
+    {
+        $shopifyClientMock = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $base = new FakeBase($shopifyClientMock);
+
+        $nullIn = $base->unserializeModel(null, FakeModel::class);
+        $nullOut = $base->serializeModel($nullIn);
+
+        $this->assertNull($nullIn);
+        $this->assertNull($nullOut);
+    }
+
+    /** @test */
+    public function unserializeModelThrowsExceptionOnInvalidData()
+    {
+        $shopifyClientMock = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $base = new FakeBase($shopifyClientMock);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $base->unserializeModel('this is supposed to be an array!', FakeModel::class);
+    }
 }


### PR DESCRIPTION
- Sometimes Shopify sends us back something like {variant:null}
- The variant service currently would attempt to deserialize null and run into an error
- I think null on a resource is not necessarily an error state and it therefore makes sense for these fns to just pass null through so that services can send null back to the consumer without error