### PR TITLE
Adding illuminate/support 5.7.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.*",
+        "illuminate/support": "5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*",
         "guzzlehttp/guzzle": "^6.2"
     },
     "autoload": {


### PR DESCRIPTION
Adding illuminate/support 5.7.* so it can be used with laravel 5.7 aswell.