### PR TITLE
Fix typo in new smart collection endpoint

### DIFF
--- a/src/Services/SmartCollection.php
+++ b/src/Services/SmartCollection.php
@@ -89,7 +89,7 @@ class SmartCollection extends CollectionEntity
      */
     public function getProductsBySmartCollectionId($id, $filter = [])
     {
-        $raw = $this->client->get("admin/smart_collections/$id/products.json", $filter);
+        $raw = $this->client->get("admin/smart_collection/$id/products.json", $filter);
 
         $products = array_map(function ($product) {
             return $this->unserializeModel($product, ShopifyProduct::class);


### PR DESCRIPTION
Removed the `s` from the [new `smart_collection/products` endpoint](https://help.shopify.com/en/api/guides/smart-collection-migration-guide#the-smart_collection-products-endpoint).