### PR TITLE
Fix custom collection model

### DIFF
--- a/src/Models/CustomCollection.php
+++ b/src/Models/CustomCollection.php
@@ -2,6 +2,7 @@
 
 namespace BoldApps\ShopifyToolkit\Models;
 
+use BoldApps\ShopifyToolkit\Contracts\Serializeable;
 use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class CustomCollection implements Serializeable, \JsonSerializable


### PR DESCRIPTION
- The custom collection model was missing its implementation of the Serializable interface.
- I added it but missed the use statement accidentally.