### PR TITLE
Add shopify api versioning

### DIFF
--- a/src/Services/Base.php
+++ b/src/Services/Base.php
@@ -7,6 +7,13 @@ use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
 
 abstract class Base
 {
+    const BASE_API_PATH = 'admin/api/%s';
+
+    const DEFAULT_API_VERSION = '2020-04';
+
+    /** @var string */
+    protected $shopifyApiVersion = self::DEFAULT_API_VERSION;
+
     /*
      * TODO: Implement an ignoredFields property
      *       We should be able to ignore a specific field on the serialization process (IE: Refund.OrderId)
@@ -138,5 +145,29 @@ abstract class Base
         }
 
         return lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $property))));
+    }
+
+    /**
+     * @return string
+     */
+    public function getApiBasePath()
+    {
+        return sprintf(self::BASE_API_PATH, $this->getShopifyApiVersion());
+    }
+
+    /**
+     * @return string
+     */
+    public function getShopifyApiVersion()
+    {
+        return $this->shopifyApiVersion;
+    }
+
+    /**
+     * @param string $shopifyApiVersion
+     */
+    public function setShopifyApiVersion(string $shopifyApiVersion)
+    {
+        $this->shopifyApiVersion = $shopifyApiVersion;
     }
 }

--- a/src/Services/Client.php
+++ b/src/Services/Client.php
@@ -5,6 +5,7 @@ namespace BoldApps\ShopifyToolkit\Services;
 use BoldApps\ShopifyToolkit\Contracts\ShopBaseInfo;
 use BoldApps\ShopifyToolkit\Contracts\ShopAccessInfo;
 use BoldApps\ShopifyToolkit\Contracts\RequestHookInterface;
+use BoldApps\ShopifyToolkit\Exceptions\BadRequestException;
 use BoldApps\ShopifyToolkit\Exceptions\NotAcceptableException;
 use BoldApps\ShopifyToolkit\Exceptions\NotFoundException;
 use BoldApps\ShopifyToolkit\Exceptions\TooManyRequestsException;
@@ -175,6 +176,7 @@ class Client
      * @throws NotAcceptableException
      * @throws UnprocessableEntityException
      * @throws TooManyRequestsException
+     * @throws BadRequestException
      */
     private function sendRequestToShopify(Request $request, array $cookies = [], $password = null)
     {
@@ -215,6 +217,8 @@ class Client
             }
 
             switch ($response->getStatusCode()) {
+                case 400:
+                    throw new BadRequestException($e->getMessage());
                 case 401:
                     throw new UnauthorizedException($e->getMessage());
                 case 404:
@@ -248,6 +252,7 @@ class Client
      * @throws UnauthorizedException
      * @throws UnprocessableEntityException
      * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws BadRequestException
      */
     private function getRedirectResponseFromShopify(Request $request)
     {
@@ -279,6 +284,8 @@ class Client
             }
 
             switch ($response->getStatusCode()) {
+                case 400:
+                    throw new BadRequestException($e->getMessage());
                 case 401:
                     throw new UnauthorizedException($e->getMessage());
                 case 404:

--- a/src/Services/Product.php
+++ b/src/Services/Product.php
@@ -79,7 +79,7 @@ class Product extends CollectionEntity
     {
         $serializedModel = ['product' => array_merge($this->serializeModel($product), ['published' => $publish])];
 
-        $raw = $this->client->post('admin/products.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/products.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['product'], ShopifyProduct::class);
     }
@@ -92,12 +92,15 @@ class Product extends CollectionEntity
      */
     public function getById($id, $filter = [])
     {
-        $raw = $this->client->get("admin/products/$id.json", $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/products/$id.json", $filter);
 
         return $this->unserializeModel($raw['product'], ShopifyProduct::class);
     }
 
     /**
+     * @deprecated Use getByParams()
+     * @see getByParams()
+     *
      * @param int   $page
      * @param int   $limit
      * @param array $filter
@@ -122,7 +125,7 @@ class Product extends CollectionEntity
      */
     public function getByParams($params)
     {
-        $raw = $this->client->get('admin/products.json', $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/products.json", $params);
 
         $products = array_map(function ($product) {
             return $this->unserializeModel($product, ShopifyProduct::class);
@@ -173,7 +176,7 @@ class Product extends CollectionEntity
     {
         $serializedModel = ['product' => $this->serializeModel($product)];
 
-        $raw = $this->client->put("admin/products/{$product->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/products/{$product->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['product'], ShopifyProduct::class);
     }
@@ -185,7 +188,7 @@ class Product extends CollectionEntity
      */
     public function delete(ShopifyProduct $product)
     {
-        return $this->client->delete("admin/products/{$product->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/products/{$product->getId()}.json");
     }
 
     /**
@@ -195,7 +198,7 @@ class Product extends CollectionEntity
      */
     public function count($filter = [])
     {
-        $raw = $this->client->get('admin/products/count.json', $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/products/count.json", $filter);
 
         return $raw['count'];
     }
@@ -220,7 +223,7 @@ class Product extends CollectionEntity
     {
         $serializedModel = ['metafield' => array_merge($this->serializeModel($metafield))];
 
-        $raw = $this->client->post("admin/products/{$product->getId()}/metafields.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/products/{$product->getId()}/metafields.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['metafield'], ShopifyMetafield::class);
     }
@@ -233,7 +236,7 @@ class Product extends CollectionEntity
      */
     public function getMetafields(ShopifyProduct $product, $filter = [])
     {
-        $raw = $this->client->get("admin/products/{$product->getId()}/metafields.json", $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/products/{$product->getId()}/metafields.json", $filter);
 
         $metafields = array_map(function ($metafield) {
             return $this->unserializeModel($metafield, ShopifyMetafield::class);
@@ -250,7 +253,7 @@ class Product extends CollectionEntity
      */
     public function getMetafield(ShopifyProduct $product, $id)
     {
-        $raw = $this->client->get("admin/products/{$product->getId()}/metafields/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/products/{$product->getId()}/metafields/$id.json");
 
         return $this->unserializeModel($raw['metafield'], ShopifyMetafield::class);
     }
@@ -263,7 +266,7 @@ class Product extends CollectionEntity
      */
     public function deleteMetafield(ShopifyProduct $product, ShopifyMetafield $metafield)
     {
-        return $this->client->delete("admin/products/{$product->getId()}/metafields/{$metafield->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/products/{$product->getId()}/metafields/{$metafield->getId()}.json");
     }
 
     /**
@@ -273,7 +276,7 @@ class Product extends CollectionEntity
      */
     public function deleteMetafieldById($metafieldId)
     {
-        return $this->client->delete("admin/metafields/{$metafieldId}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/metafields/{$metafieldId}.json");
     }
 
     /**


### PR DESCRIPTION
Initial proposal changes to implement the Shopify API versioning.

* Added a few things to the Base class
  * Setting a default Shopify API version 
  * Allowing the ability to override the default Shopify API version
  * Setting a base path for the API routes, allowing future changes to only need to be made in one place
* Updated the Product service to use the base path 
* Deprecating the `getAll()` method in the Product service 
* Catching BadRequestExceptions in the Client to catch if a `page` filter makes it through