### PR TITLE
Adding API versioning to remaining Service classes

### DIFF
--- a/src/Services/Application.php
+++ b/src/Services/Application.php
@@ -21,6 +21,6 @@ class Application extends Base
      */
     public function uninstall()
     {
-        return $this->client->delete('admin/api_permissions/current.json');
+        return $this->client->delete("{$this->getApiBasePath()}/api_permissions/current.json");
     }
 }

--- a/src/Services/ApplicationCharge.php
+++ b/src/Services/ApplicationCharge.php
@@ -15,7 +15,7 @@ class ApplicationCharge extends Base
     {
         $serializedModel = ['application_charge' => $this->serializeModel($applicationCharge)];
 
-        $raw = $this->client->post('admin/application_charges.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/application_charges.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['application_charge'], ShopifyApplicationCharge::class);
     }
@@ -27,7 +27,7 @@ class ApplicationCharge extends Base
      */
     public function getById($id)
     {
-        $charge = $this->client->get("admin/application_charges/$id.json");
+        $charge = $this->client->get("{$this->getApiBasePath()}/application_charges/$id.json");
 
         return $this->unserializeModel($charge['application_charge'], ShopifyApplicationCharge::class);
     }
@@ -42,7 +42,7 @@ class ApplicationCharge extends Base
         $id = $applicationCharge->getId();
         $serializedModel = ['application_charge' => $this->serializeModel($applicationCharge)];
 
-        $raw = $this->client->post("admin/application_charges/$id/activate.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/application_charges/$id/activate.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['application_charge'], ShopifyApplicationCharge::class);
     }
@@ -54,6 +54,6 @@ class ApplicationCharge extends Base
      */
     public function delete(ShopifyApplicationCharge $applicationCharge)
     {
-        return $this->client->delete("admin/application_charges/{$applicationCharge->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/application_charges/{$applicationCharge->getId()}.json");
     }
 }

--- a/src/Services/Asset.php
+++ b/src/Services/Asset.php
@@ -63,7 +63,7 @@ class Asset extends Base
         $themeId = $this->currentTheme->getId();
 
         try {
-            $raw = $this->client->get("admin/themes/$themeId/assets.json", [
+            $raw = $this->client->get("{$this->getApiBasePath()}/themes/$themeId/assets.json", [
                 'asset' => [
                     'key' => $key,
                 ],
@@ -87,7 +87,7 @@ class Asset extends Base
 
         $themeId = $this->currentTheme->getId();
 
-        $raw = $this->client->get("admin/themes/$themeId/assets.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/themes/$themeId/assets.json");
 
         $assets = array_map(function ($asset) {
             return $this->unserializeModel($asset, AssetModel::class);
@@ -127,7 +127,7 @@ class Asset extends Base
 
         $serializedModel = ['asset' => $this->serializeModel($asset)];
 
-        $raw = $this->client->put("admin/themes/$themeId/assets.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/themes/$themeId/assets.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['asset'], AssetModel::class);
     }
@@ -155,7 +155,7 @@ class Asset extends Base
 
         $themeId = $this->currentTheme->getId();
 
-        return $this->client->delete("admin/themes/$themeId/assets.json", [
+        return $this->client->delete("{$this->getApiBasePath()}/themes/$themeId/assets.json", [
             'asset' => [
                 'key' => $key,
             ],

--- a/src/Services/Collect.php
+++ b/src/Services/Collect.php
@@ -27,7 +27,7 @@ class Collect extends Base
     {
         $serializedModel = ['collect' => array_merge($this->serializeModel($collect))];
 
-        $raw = $this->client->post('admin/collects.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/collects.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['collect'], ShopifyCollect::class);
     }
@@ -39,7 +39,7 @@ class Collect extends Base
      */
     public function getById($id)
     {
-        $raw = $this->client->get("admin/collects/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/collects/$id.json");
 
         return $this->unserializeModel($raw['collect'], ShopifyCollect::class);
     }
@@ -51,7 +51,7 @@ class Collect extends Base
      */
     public function getByParams($params = [])
     {
-        $raw = $this->client->get('admin/collects.json', $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/collects.json", $params);
 
         $priceRules = array_map(function ($collect) {
             return $this->unserializeModel($collect, ShopifyCollect::class);
@@ -67,7 +67,7 @@ class Collect extends Base
      */
     public function count($params = [])
     {
-        $raw = $this->client->get('admin/collects/count.json', $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/collects/count.json", $params);
 
         return $raw['count'];
     }
@@ -79,7 +79,7 @@ class Collect extends Base
      */
     public function delete(ShopifyCollect $collect)
     {
-        return $this->client->delete("admin/collects/{$collect->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/collects/{$collect->getId()}.json");
     }
 
     /**

--- a/src/Services/Country.php
+++ b/src/Services/Country.php
@@ -16,7 +16,7 @@ class Country extends Base
     {
         $serializedModel = ['country' => $this->serializeModel($country)];
 
-        $raw = $this->client->post('admin/countries.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/countries.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['country'], ShopifyCountry::class);
     }
@@ -38,12 +38,15 @@ class Country extends Base
      */
     public function count($filter = [])
     {
-        $raw = $this->client->get('admin/countries/count.json', $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/countries/count.json", $filter);
 
         return $raw['count'];
     }
 
     /**
+     * @deprecated Use getByParams()
+     * @see getByParams()
+     *
      * @param array $filter
      *
      * @return Collection
@@ -60,6 +63,22 @@ class Country extends Base
     }
 
     /**
+     * @param array $params
+     *
+     * @return Collection
+     */
+    public function getByParams($params = [])
+    {
+        $raw = $this->client->get("{$this->getApiBasePath()}/countries.json", $params);
+
+        $countries = array_map(function ($country) {
+            return $this->unserializeModel($country, ShopifyCountry::class);
+        }, $raw['countries']);
+
+        return new Collection($countries);
+    }
+
+    /**
      * @param int   $countryId
      * @param array $filter
      *
@@ -67,7 +86,7 @@ class Country extends Base
      */
     public function getById($countryId, $filter = [])
     {
-        $raw = $this->client->get("admin/countries/$countryId.json", $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/countries/$countryId.json", $filter);
 
         return $this->unserializeModel($raw['country'], ShopifyCountry::class);
     }
@@ -80,7 +99,7 @@ class Country extends Base
     public function update(ShopifyCountry $country)
     {
         $serializedModel = ['country' => $this->serializeModel($country)];
-        $raw = $this->client->put("admin/countries/{$country->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/countries/{$country->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['country'], ShopifyCountry::class);
     }
@@ -92,6 +111,6 @@ class Country extends Base
      */
     public function delete(ShopifyCountry $country)
     {
-        return $this->client->delete("admin/countries/{$country->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/countries/{$country->getId()}.json");
     }
 }

--- a/src/Services/CustomCollection.php
+++ b/src/Services/CustomCollection.php
@@ -17,7 +17,7 @@ class CustomCollection extends CollectionEntity
     {
         $serializedModel = ['custom_collection' => array_merge($this->serializeModel($collection), ['published' => $publish])];
 
-        $raw = $this->client->post('admin/custom_collections.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/custom_collections.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['custom_collection'], ShopifyCustomCollection::class);
     }
@@ -29,12 +29,15 @@ class CustomCollection extends CollectionEntity
      */
     public function getById($id)
     {
-        $raw = $this->client->get("admin/custom_collections/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/custom_collections/$id.json");
 
         return $this->unserializeModel($raw['custom_collection'], ShopifyCustomCollection::class);
     }
 
     /**
+     * @deprecated Use getByParams()
+     * @see getByParams()
+     *
      * @param int   $page
      * @param int   $limit
      * @param array $filter
@@ -59,7 +62,7 @@ class CustomCollection extends CollectionEntity
      */
     public function getByParams($params)
     {
-        $raw = $this->client->get('admin/custom_collections.json', $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/custom_collections.json", $params);
 
         $collection = array_map(function ($product) {
             return $this->unserializeModel($product, ShopifyCustomCollection::class);
@@ -77,7 +80,7 @@ class CustomCollection extends CollectionEntity
     {
         $serializedModel = ['custom_collection' => $this->serializeModel($collection)];
 
-        $raw = $this->client->put("admin/custom_collections/{$collection->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/custom_collections/{$collection->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['custom_collection'], ShopifyCustomCollection::class);
     }
@@ -89,7 +92,7 @@ class CustomCollection extends CollectionEntity
      */
     public function delete(ShopifyCustomCollection $collection)
     {
-        return $this->client->delete("admin/custom_collections/{$collection->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/custom_collections/{$collection->getId()}.json");
     }
 
     /**
@@ -99,7 +102,7 @@ class CustomCollection extends CollectionEntity
      */
     public function count($filter = [])
     {
-        $raw = $this->client->get('admin/custom_collections/count.json', $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/custom_collections/count.json", $filter);
 
         return $raw['count'];
     }
@@ -111,7 +114,7 @@ class CustomCollection extends CollectionEntity
      */
     public function countByParams($filter = [])
     {
-        $raw = $this->client->get('admin/custom_collections/count.json', $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/custom_collections/count.json", $filter);
 
         return $raw['count'];
     }

--- a/src/Services/Customer.php
+++ b/src/Services/Customer.php
@@ -14,12 +14,15 @@ class Customer extends CollectionEntity
      */
     public function getById($id)
     {
-        $raw = $this->client->get("admin/customers/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/customers/$id.json");
 
         return $this->unserializeModel($raw['customer'], ShopifyCustomer::class);
     }
 
     /**
+     * @deprecated Use getByParams()
+     * @see getByParams()
+     *
      * @param int   $page
      * @param int   $limit
      * @param array $filter
@@ -44,7 +47,7 @@ class Customer extends CollectionEntity
      */
     public function getByParams($params)
     {
-        $raw = $this->client->get('admin/customers.json', $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/customers.json", $params);
 
         $customers = array_map(function ($customer) {
             return $this->unserializeModel($customer, ShopifyCustomer::class);
@@ -60,7 +63,7 @@ class Customer extends CollectionEntity
      */
     public function searchByParams($parms)
     {
-        $raw = $this->client->get('admin/customers/search.json', $parms);
+        $raw = $this->client->get("{$this->getApiBasePath()}/customers/search.json", $parms);
 
         $customers = array_map(function ($customer) {
             return $this->unserializeModel($customer, ShopifyCustomer::class);
@@ -76,7 +79,7 @@ class Customer extends CollectionEntity
      */
     public function count($filter = [])
     {
-        $raw = $this->client->get('admin/customers/count.json', $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/customers/count.json", $filter);
 
         return $raw['count'];
     }
@@ -88,7 +91,7 @@ class Customer extends CollectionEntity
      */
     public function countByParams($filter = [])
     {
-        $raw = $this->client->get('admin/customers/count.json', $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/customers/count.json", $filter);
 
         return $raw['count'];
     }
@@ -112,7 +115,7 @@ class Customer extends CollectionEntity
     {
         $serializedModel = ['customer' => array_merge($this->serializeModel($customer))];
 
-        $raw = $this->client->post('admin/customers.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/customers.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['customer'], ShopifyCustomer::class);
     }
@@ -126,7 +129,7 @@ class Customer extends CollectionEntity
     {
         $serializedModel = ['customer' => $this->serializeModel($customer)];
 
-        $raw = $this->client->put("admin/customers/{$customer->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/customers/{$customer->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['customer'], ShopifyCustomer::class);
     }
@@ -138,7 +141,7 @@ class Customer extends CollectionEntity
      */
     public function delete(ShopifyCustomer $customer)
     {
-        return $this->client->delete("admin/customers/{$customer->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/customers/{$customer->getId()}.json");
     }
 
     /**
@@ -150,6 +153,6 @@ class Customer extends CollectionEntity
      */
     public function sendAccountCreationInvite($shopifyCustomerId, $params = [], $body = [])
     {
-        return $this->client->post("admin/customers/{$shopifyCustomerId}/send_invite.json", $params, $body);
+        return $this->client->post("{$this->getApiBasePath()}/customers/{$shopifyCustomerId}/send_invite.json", $params, $body);
     }
 }

--- a/src/Services/CustomerAddress.php
+++ b/src/Services/CustomerAddress.php
@@ -17,12 +17,15 @@ class CustomerAddress extends Base
     public function getById($customer, $id)
     {
         $customerId = $customer->getId();
-        $raw = $this->client->get("admin/customers/$customerId/addresses/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/customers/$customerId/addresses/$id.json");
 
         return $this->unserializeModel($raw['customer_address'], ShopifyCustomerAddress::class);
     }
 
     /**
+     * @deprecated Use getByParams()
+     * @see getByParams()
+     *
      * @param ShopifyCustomer $customer
      * @param int             $page
      * @param int             $limit
@@ -43,6 +46,24 @@ class CustomerAddress extends Base
     }
 
     /**
+     * @param ShopifyCustomer $customer
+     * @param array           $params
+     *
+     * @return Collection
+     */
+    public function getByParams($customer, $params = [])
+    {
+        $customerId = $customer->getId();
+        $raw = $this->client->get("{$this->getApiBasePath()}/customers/$customerId/addresses.json", $params);
+
+        $customers = array_map(function ($product) {
+            return $this->unserializeModel($product, ShopifyCustomerAddress::class);
+        }, $raw['addresses']);
+
+        return new Collection($customers);
+    }
+
+    /**
      * @param ShopifyCustomer        $customer
      * @param ShopifyCustomerAddress $address
      *
@@ -53,7 +74,7 @@ class CustomerAddress extends Base
         $customerId = $customer->getId();
         $serializedModel = ['address' => array_merge($this->serializeModel($address))];
 
-        $raw = $this->client->post("admin/customers/$customerId/addresses.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/customers/$customerId/addresses.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['customer_address'], ShopifyCustomerAddress::class);
     }

--- a/src/Services/CustomerSavedSearch.php
+++ b/src/Services/CustomerSavedSearch.php
@@ -38,7 +38,7 @@ class CustomerSavedSearch extends CollectionEntity
     {
         $serializedModel = ['customer_saved_search' => array_merge($this->serializeModel($customerSavedSearch))];
 
-        $raw = $this->client->post('admin/customer_saved_searches.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/customer_saved_searches.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['customer_saved_search'], CustomerSavedSearchModel::class);
     }
@@ -52,7 +52,7 @@ class CustomerSavedSearch extends CollectionEntity
     {
         $serializedModel = ['customer_saved_search' => array_merge($this->serializeModel($customerSavedSearch))];
 
-        $raw = $this->client->put("admin/customer_saved_searches/{$customerSavedSearch->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/customer_saved_searches/{$customerSavedSearch->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['customer_saved_search'], CustomerSavedSearchModel::class);
     }
@@ -64,7 +64,7 @@ class CustomerSavedSearch extends CollectionEntity
      */
     public function delete(CustomerSavedSearchModel $customerSavedSearch)
     {
-        return $this->client->delete("admin/customer_saved_searches/{$customerSavedSearch->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/customer_saved_searches/{$customerSavedSearch->getId()}.json");
     }
 
     /**
@@ -74,7 +74,7 @@ class CustomerSavedSearch extends CollectionEntity
      */
     public function getByParams($params)
     {
-        $raw = $this->client->get('admin/customer_saved_searches.json', $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/customer_saved_searches.json", $params);
 
         $customers = array_map(function ($customer) {
             return $this->unserializeModel($customer, CustomerSavedSearchModel::class);
@@ -91,7 +91,7 @@ class CustomerSavedSearch extends CollectionEntity
      */
     public function getAllCustomersById($customerSavedSearchId, $params = [])
     {
-        $raw = $this->client->get("admin/customer_saved_searches/$customerSavedSearchId/customers.json", $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/customer_saved_searches/$customerSavedSearchId/customers.json", $params);
 
         $customers = array_map(function ($customer) {
             return $this->unserializeModel($customer, CustomerModel::class);

--- a/src/Services/DiscountCode.php
+++ b/src/Services/DiscountCode.php
@@ -16,7 +16,7 @@ class DiscountCode extends Base
     {
         $serializedModel = ['discount_code' => $this->serializeModel($discountCode)];
         $priceRuleId = $discountCode->getPriceRuleId();
-        $raw = $this->client->post("admin/price_rules/$priceRuleId/discount_codes.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/price_rules/$priceRuleId/discount_codes.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['discount_code'], ShopifyDiscountCode::class);
     }
@@ -39,7 +39,7 @@ class DiscountCode extends Base
      */
     public function getAllByPriceRuleId($priceRuleId, $filter = [])
     {
-        $raw = $this->client->get("admin/price_rules/$priceRuleId/discount_codes.json", $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/price_rules/$priceRuleId/discount_codes.json", $filter);
 
         $discountCodes = array_map(function ($discountCode) {
             return $this->unserializeModel($discountCode, ShopifyDiscountCode::class);
@@ -56,7 +56,7 @@ class DiscountCode extends Base
      */
     public function getByDiscountCodeId($priceRuleId, $discountCodeId)
     {
-        $raw = $this->client->get("admin/price_rules/$priceRuleId/discount_codes/$discountCodeId.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/price_rules/$priceRuleId/discount_codes/$discountCodeId.json");
 
         return $this->unserializeModel($raw['discount_code'], ShopifyDiscountCode::class);
     }
@@ -69,7 +69,7 @@ class DiscountCode extends Base
     public function lookup($discountCode)
     {
         $result = null;
-        $redirectLocation = $this->client->getRedirectLocation('admin/discount_codes/lookup.json', ['code' => $discountCode]);
+        $redirectLocation = $this->client->getRedirectLocation("{$this->getApiBasePath()}/discount_codes/lookup.json", ['code' => $discountCode]);
 
         if (!empty($redirectLocation)) {
             $raw = $this->client->get($redirectLocation);
@@ -88,7 +88,7 @@ class DiscountCode extends Base
     {
         $serializedModel = ['price_rule' => $this->serializeModel($discountCode)];
         $priceRuleId = $discountCode->getPriceRuleId();
-        $raw = $this->client->put("admin/price_rules/$priceRuleId/{$discountCode->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/price_rules/$priceRuleId/{$discountCode->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['price_rule'], ShopifyDiscountCode::class);
     }
@@ -102,6 +102,6 @@ class DiscountCode extends Base
     {
         $priceRuleId = $discountCode->getPriceRuleId();
 
-        return $this->client->delete("admin/price_rules/$priceRuleId/discount_codes/{$discountCode->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/price_rules/$priceRuleId/discount_codes/{$discountCode->getId()}.json");
     }
 }

--- a/src/Services/DraftOrder.php
+++ b/src/Services/DraftOrder.php
@@ -69,7 +69,7 @@ class DraftOrder extends Base
     public function create($shopifyDraftOrder)
     {
         $serializedModel = ['draft_order' => $this->serializeModel($shopifyDraftOrder)];
-        $raw = $this->client->post('admin/draft_orders.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/draft_orders.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['draft_order'], ShopifyDraftOrder::class);
     }
@@ -81,7 +81,7 @@ class DraftOrder extends Base
      */
     public function getById($id)
     {
-        $raw = $this->client->get("admin/draft_orders/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/draft_orders/$id.json");
 
         $result = $this->unserializeModel($raw['draft_order'], ShopifyDraftOrder::class);
 
@@ -130,7 +130,7 @@ class DraftOrder extends Base
      */
     public function delete($id)
     {
-        return $this->client->delete("admin/draft_orders/$id.json");
+        return $this->client->delete("{$this->getApiBasePath()}/draft_orders/$id.json");
     }
 
     /**

--- a/src/Services/Fulfillment.php
+++ b/src/Services/Fulfillment.php
@@ -15,7 +15,7 @@ class Fulfillment extends Base
     {
         $serializedModel = ['fulfillment' => $this->serializeModel($fulfillment)];
 
-        $raw = $this->client->post("admin/orders/{$fulfillment->getOrderId()}/fulfillments.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/orders/{$fulfillment->getOrderId()}/fulfillments.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['fulfillment'], ShopifyFulfillment::class);
     }
@@ -27,7 +27,7 @@ class Fulfillment extends Base
      */
     public function get($orderId)
     {
-        $raw = $this->client->get("admin/orders/{$orderId}/fulfillments.json", []);
+        $raw = $this->client->get("{$this->getApiBasePath()}/orders/{$orderId}/fulfillments.json", []);
         $results = collect();
         foreach ($raw['fulfillments'] as $fulfillment) {
             $results->push($this->unserializeModel($fulfillment, ShopifyFulfillment::class));

--- a/src/Services/Image.php
+++ b/src/Services/Image.php
@@ -18,7 +18,7 @@ class Image extends Base
     {
         $serializedModel = ['image' => $this->serializeModel($image)];
 
-        $raw = $this->client->post("admin/products/{$product->getId()}/images.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/products/{$product->getId()}/images.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['image'], ShopifyImage::class);
     }
@@ -41,7 +41,7 @@ class Image extends Base
      */
     public function getAllProductImages(ShopifyProduct $product, $params = [])
     {
-        $raw = $this->client->get("admin/products/{$product->getId()}/images.json", $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/products/{$product->getId()}/images.json", $params);
 
         $images = array_map(function ($image) {
             return $this->unserializeModel($image, ShopifyImage::class);
@@ -58,7 +58,7 @@ class Image extends Base
      */
     public function getProductImageById(ShopifyProduct $product, $id)
     {
-        $raw = $this->client->get("admin/products/{$product->getId()}/images/{$id}.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/products/{$product->getId()}/images/{$id}.json");
 
         return $this->unserializeModel($raw['image'], ShopifyImage::class);
     }
@@ -71,6 +71,6 @@ class Image extends Base
      */
     public function deleteProductImage(ShopifyProduct $product, ShopifyImage $image)
     {
-        return $this->client->delete("admin/products/{$product->getId()}/images/{$image->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/products/{$product->getId()}/images/{$image->getId()}.json");
     }
 }

--- a/src/Services/InventoryLevel.php
+++ b/src/Services/InventoryLevel.php
@@ -24,7 +24,7 @@ class InventoryLevel extends Base
      */
     public function getByParams($params)
     {
-        $raw = $this->client->get('admin/inventory_levels.json', $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/inventory_levels.json", $params);
 
         $inventoryLevels = array_map(function ($priceRule) {
             return $this->unserializeModel($priceRule, ShopifyInventoryLevel::class);
@@ -42,7 +42,7 @@ class InventoryLevel extends Base
      */
     public function adjust($locationId, $inventoryItemId, $availableAdjustment)
     {
-        $raw = $this->client->post('admin/inventory_levels/adjust.json', [], [
+        $raw = $this->client->post("{$this->getApiBasePath()}/inventory_levels/adjust.json", [], [
             'location_id' => $locationId,
             'inventory_item_id' => $inventoryItemId,
             'available_adjustment' => $availableAdjustment,
@@ -61,7 +61,7 @@ class InventoryLevel extends Base
      */
     public function set($locationId, $inventoryItemId, $available, $disconnectIfNecessary = false)
     {
-        $raw = $this->client->post('admin/inventory_levels/set.json', [], [
+        $raw = $this->client->post("{$this->getApiBasePath()}/inventory_levels/set.json", [], [
             'location_id' => $locationId,
             'inventory_item_id' => $inventoryItemId,
             'available' => $available,
@@ -80,7 +80,7 @@ class InventoryLevel extends Base
      */
     public function connect($locationId, $inventoryItemId, $relocateIfNecessary = false)
     {
-        $raw = $this->client->post('admin/inventory_levels/connect.json', [], [
+        $raw = $this->client->post("{$this->getApiBasePath()}/inventory_levels/connect.json", [], [
             'location_id' => $locationId,
             'inventory_item_id' => $inventoryItemId,
             'relocate_if_necessary' => $relocateIfNecessary,
@@ -96,7 +96,7 @@ class InventoryLevel extends Base
      */
     public function delete(ShopifyInventoryLevel $inventoryLevel)
     {
-        return $this->client->delete('admin/inventory_levels.json', [
+        return $this->client->delete("{$this->getApiBasePath()}/inventory_levels.json", [
             'inventory_item_id' => $inventoryLevel->getInventoryItemId(),
             'location_id' => $inventoryLevel->getLocationId(),
         ]);

--- a/src/Services/Location.php
+++ b/src/Services/Location.php
@@ -23,7 +23,7 @@ class Location extends Base
      */
     public function getAll()
     {
-        $raw = $this->client->get('admin/locations.json');
+        $raw = $this->client->get("{$this->getApiBasePath()}/locations.json");
 
         $locations = array_map(function ($location) {
             return $this->unserializeModel($location, ShopifyLocation::class);
@@ -39,7 +39,7 @@ class Location extends Base
      */
     public function getById($id)
     {
-        $raw = $this->client->get("admin/locations/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/locations/$id.json");
 
         return $this->unserializeModel($raw['location'], ShopifyLocation::class);
     }
@@ -49,7 +49,7 @@ class Location extends Base
      */
     public function count()
     {
-        $raw = $this->client->get('admin/locations/count.json');
+        $raw = $this->client->get("{$this->getApiBasePath()}/locations/count.json");
 
         return $raw['count'];
     }
@@ -61,7 +61,7 @@ class Location extends Base
      */
     public function getLocationInventoryLevels($id)
     {
-        $raw = $this->client->get("admin/locations/$id/inventory_levels.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/locations/$id/inventory_levels.json");
 
         $inventoryLevels = array_map(function ($inventoryLevel) {
             return $this->unserializeModel($inventoryLevel, ShopifyInventoryLevel::class);

--- a/src/Services/Order.php
+++ b/src/Services/Order.php
@@ -50,12 +50,15 @@ class Order extends CollectionEntity
      */
     public function getById($id)
     {
-        $raw = $this->client->get("admin/orders/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/orders/$id.json");
 
         return $this->unserializeModel($raw['order'], ShopifyOrder::class);
     }
 
     /**
+     * @deprecated Use getByParams()
+     * @see getByParams()
+     *
      * @param int   $page
      * @param int   $limit
      * @param array $filter
@@ -79,7 +82,7 @@ class Order extends CollectionEntity
      */
     public function getByParams($params)
     {
-        $raw = $this->client->get('admin/orders.json', $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/orders.json", $params);
 
         $orders = array_map(function ($order) {
             return $this->unserializeModel($order, ShopifyOrder::class);
@@ -95,7 +98,7 @@ class Order extends CollectionEntity
      */
     public function count($filter = [])
     {
-        $raw = $this->client->get('admin/orders/count.json', $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/orders/count.json", $filter);
 
         return $raw['count'];
     }
@@ -107,7 +110,7 @@ class Order extends CollectionEntity
      */
     public function countByParams($filter = [])
     {
-        $raw = $this->client->get('admin/orders/count.json', $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/orders/count.json", $filter);
 
         return $raw['count'];
     }
@@ -121,7 +124,7 @@ class Order extends CollectionEntity
     {
         $serializedModel = ['order' => $this->serializeModel($order)];
 
-        $raw = $this->client->put("admin/orders/{$order->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/orders/{$order->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['order'], ShopifyOrder::class);
     }
@@ -135,7 +138,7 @@ class Order extends CollectionEntity
     {
         $serializedModel = ['order' => $this->serializeModel($order)];
 
-        $raw = $this->client->post('admin/orders.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/orders.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['order'], ShopifyOrder::class);
     }
@@ -151,7 +154,7 @@ class Order extends CollectionEntity
 
         $serializedModel = ['order' => $this->serializeModel($order)];
 
-        $raw = $this->client->post('admin/orders.json', [], $serializedModel, [], null, false, ['X-Shopify-Api-Features' => 'creates-test-orders']);
+        $raw = $this->client->post("{$this->getApiBasePath()}/orders.json", [], $serializedModel, [], null, false, ['X-Shopify-Api-Features' => 'creates-test-orders']);
 
         return $this->unserializeModel($raw['order'], ShopifyOrder::class);
     }

--- a/src/Services/PriceRule.php
+++ b/src/Services/PriceRule.php
@@ -14,12 +14,15 @@ class PriceRule extends CollectionEntity
      */
     public function getById($id)
     {
-        $raw = $this->client->get("admin/price_rules/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/price_rules/$id.json");
 
         return $this->unserializeModel($raw['price_rule'], ShopifyPriceRule::class);
     }
 
     /**
+     * @deprecated Use getByParams()
+     * @see getByParams()
+     *
      * @param int   $page
      * @param int   $limit
      * @param array $filter
@@ -44,7 +47,7 @@ class PriceRule extends CollectionEntity
      */
     public function getByParams($params)
     {
-        $raw = $this->client->get('admin/price_rules.json', $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/price_rules.json", $params);
 
         $priceRules = array_map(function ($priceRule) {
             return $this->unserializeModel($priceRule, ShopifyPriceRule::class);
@@ -62,7 +65,7 @@ class PriceRule extends CollectionEntity
     {
         $serializedModel = ['price_rule' => array_merge($this->serializeModel($priceRule))];
 
-        $raw = $this->client->post('admin/price_rules.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/price_rules.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['price_rule'], ShopifyPriceRule::class);
     }
@@ -86,7 +89,7 @@ class PriceRule extends CollectionEntity
     {
         $serializedModel = ['price_rule' => $this->serializeModel($priceRule)];
 
-        $raw = $this->client->put("admin/price_rules/{$priceRule->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/price_rules/{$priceRule->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['price_rule'], ShopifyPriceRule::class);
     }
@@ -98,6 +101,6 @@ class PriceRule extends CollectionEntity
      */
     public function delete(ShopifyPriceRule $priceRule)
     {
-        return $this->client->delete("admin/price_rules/{$priceRule->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/price_rules/{$priceRule->getId()}.json");
     }
 }

--- a/src/Services/RecurringApplicationCharge.php
+++ b/src/Services/RecurringApplicationCharge.php
@@ -16,7 +16,7 @@ class RecurringApplicationCharge extends Base
     {
         $serializedModel = ['recurring_application_charge' => $this->serializeModel($recurringApplicationCharge)];
 
-        $raw = $this->client->post('admin/recurring_application_charges.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/recurring_application_charges.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['recurring_application_charge'], ShopifyRecurringApplicationCharge::class);
     }
@@ -28,7 +28,7 @@ class RecurringApplicationCharge extends Base
      */
     public function getById($id)
     {
-        $charge = $this->client->get("admin/recurring_application_charges/$id.json");
+        $charge = $this->client->get("{$this->getApiBasePath()}/recurring_application_charges/$id.json");
 
         return $this->unserializeModel($charge['recurring_application_charge'], ShopifyRecurringApplicationCharge::class);
     }
@@ -38,7 +38,7 @@ class RecurringApplicationCharge extends Base
      */
     public function getAll()
     {
-        $raw = $this->client->get('/admin/recurring_application_charges.json');
+        $raw = $this->client->get("{$this->getApiBasePath()}/recurring_application_charges.json");
         $charges = array_map(function ($charge) {
             return $this->unserializeModel($charge, ShopifyRecurringApplicationCharge::class);
         }, $raw['recurring_application_charges']);
@@ -56,7 +56,7 @@ class RecurringApplicationCharge extends Base
         $id = $recurringApplicationCharge->getId();
         $serializedModel = ['recurring_application_charge' => $this->serializeModel($recurringApplicationCharge)];
 
-        $raw = $this->client->post("admin/recurring_application_charges/$id/activate.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/recurring_application_charges/$id/activate.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['recurring_application_charge'], ShopifyRecurringApplicationCharge::class);
     }
@@ -68,7 +68,7 @@ class RecurringApplicationCharge extends Base
      */
     public function delete(ShopifyRecurringApplicationCharge $recurringApplicationCharge)
     {
-        return $this->client->delete("admin/recurring_application_charges/{$recurringApplicationCharge->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/recurring_application_charges/{$recurringApplicationCharge->getId()}.json");
     }
 
     /**

--- a/src/Services/Refund.php
+++ b/src/Services/Refund.php
@@ -60,7 +60,7 @@ class Refund extends Base
     {
         $serializedModel = ['refund' => $this->serializeModel($refund)];
 
-        $raw = $this->client->post("admin/orders/{$refund->getOrderId()}/refunds.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/orders/{$refund->getOrderId()}/refunds.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['refund'], ShopifyRefund::class);
     }
@@ -74,7 +74,7 @@ class Refund extends Base
     {
         $serializedModel = ['refund' => $this->serializeModel($refund)];
 
-        $raw = $this->client->post("admin/orders/{$refund->getOrderId()}/refunds/calculate.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/orders/{$refund->getOrderId()}/refunds/calculate.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['refund'], ShopifyRefund::class);
     }

--- a/src/Services/Script.php
+++ b/src/Services/Script.php
@@ -16,7 +16,7 @@ class Script extends Base
     {
         $serializedModel = ['script_tag' => $this->serializeModel($script)];
 
-        $raw = $this->client->post('admin/script_tags.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/script_tags.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['script_tag'], ShopifyScript::class);
     }
@@ -26,7 +26,7 @@ class Script extends Base
      */
     public function get()
     {
-        $raw = $this->client->get('admin/script_tags.json');
+        $raw = $this->client->get("{$this->getApiBasePath()}/script_tags.json");
 
         $scripts = array_map(function ($script) {
             return $this->unserializeModel($script, ShopifyScript::class);
@@ -42,7 +42,7 @@ class Script extends Base
      */
     public function getByUrl($url)
     {
-        $raw = $this->client->get('admin/script_tags.json?src='.$url);
+        $raw = $this->client->get("{$this->getApiBasePath()}/script_tags.json?src=$url");
 
         $scripts = array_map(function ($script) {
             return $this->unserializeModel($script, ShopifyScript::class);
@@ -60,7 +60,7 @@ class Script extends Base
     {
         $serializedModel = ['script_tag' => $this->serializeModel($script)];
 
-        $raw = $this->client->put("admin/script_tag/{$script->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/script_tag/{$script->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['script_tag'], ShopifyScript::class);
     }
@@ -72,6 +72,6 @@ class Script extends Base
      */
     public function delete(ShopifyScript $script)
     {
-        return $this->client->delete("admin/script_tags/{$script->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/script_tags/{$script->getId()}.json");
     }
 }

--- a/src/Services/ShippingZone.php
+++ b/src/Services/ShippingZone.php
@@ -9,6 +9,9 @@ use BoldApps\ShopifyToolkit\Models\ShippingZone as ShippingZoneModel;
 class ShippingZone extends Base
 {
     /**
+     * @deprecated Use getByParams()
+     * @see getByParams()
+     *
      * @param int   $page
      * @param int   $limit
      * @param array $filter
@@ -21,6 +24,24 @@ class ShippingZone extends Base
             'page' => $page,
             'limit' => $limit,
         ], $filter));
+
+        $shippingZones = array_map(function ($zone) {
+            $zone['countries'] = $this->unserializeCountries($zone['countries']);
+
+            return $this->unserializeModel($zone, ShippingZoneModel::class);
+        }, $raw['shipping_zones']);
+
+        return collect($shippingZones);
+    }
+
+    /**
+     * @param array $params
+     *
+     * @return Collection
+     */
+    public function getByParams($params = [])
+    {
+        $raw = $this->client->get("{$this->getApiBasePath()}/shipping_zones.json", $params);
 
         $shippingZones = array_map(function ($zone) {
             $zone['countries'] = $this->unserializeCountries($zone['countries']);

--- a/src/Services/Shop.php
+++ b/src/Services/Shop.php
@@ -21,7 +21,7 @@ class Shop extends Base
      */
     public function asArray()
     {
-        $raw = $this->client->get('admin/shop.json');
+        $raw = $this->client->get("{$this->getApiBasePath()}/shop.json");
 
         return $raw['shop'];
     }
@@ -36,7 +36,7 @@ class Shop extends Base
     {
         $serializedModel = ['metafield' => array_merge($this->serializeModel($metafield))];
 
-        $raw = $this->client->post('admin/metafields.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/metafields.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['metafield'], ShopifyMetafield::class);
     }
@@ -48,7 +48,7 @@ class Shop extends Base
      */
     public function getMetafield(ShopifyMetafield $metafield)
     {
-        $raw = $this->client->get("admin/metafields/{$metafield->getId()}.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/metafields/{$metafield->getId()}.json");
 
         return $this->unserializeModel($raw['metafield'], ShopifyMetafield::class);
     }
@@ -60,7 +60,7 @@ class Shop extends Base
      */
     public function getMetafields(array $params = [])
     {
-        $raw = $this->client->get('admin/metafields.json', $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/metafields.json", $params);
 
         $metafields = array_map(function ($metafield) {
             return $this->unserializeModel($metafield, ShopifyMetafield::class);
@@ -76,6 +76,6 @@ class Shop extends Base
      */
     public function deleteMetafield(ShopifyMetafield $metafield)
     {
-        return $this->client->delete("admin/metafields/{$metafield->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/metafields/{$metafield->getId()}.json");
     }
 }

--- a/src/Services/SmartCollection.php
+++ b/src/Services/SmartCollection.php
@@ -54,7 +54,7 @@ class SmartCollection extends CollectionEntity
             'smart_collection' => array_merge($this->serializeModel($collection), ['published' => $publish]),
         ];
 
-        $raw = $this->client->post('admin/smart_collections.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/smart_collections.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['smart_collection'], ShopifySmartCollection::class);
     }
@@ -76,7 +76,7 @@ class SmartCollection extends CollectionEntity
      */
     public function getById($id)
     {
-        $raw = $this->client->get("admin/smart_collections/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/smart_collections/$id.json");
 
         return $this->unserializeModel($raw['smart_collection'], ShopifySmartCollection::class);
     }
@@ -89,7 +89,7 @@ class SmartCollection extends CollectionEntity
      */
     public function getProductsBySmartCollectionId($id, $filter = [])
     {
-        $raw = $this->client->get("admin/smart_collections/$id/products.json", $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/smart_collections/$id/products.json", $filter);
 
         $products = array_map(function ($product) {
             return $this->unserializeModel($product, ShopifyProduct::class);
@@ -99,6 +99,9 @@ class SmartCollection extends CollectionEntity
     }
 
     /**
+     * @deprecated Use getByParams()
+     * @see getByParams()
+     *
      * @param int   $page
      * @param int   $limit
      * @param array $filter
@@ -124,7 +127,7 @@ class SmartCollection extends CollectionEntity
      */
     public function getByParams($params)
     {
-        $raw = $this->client->get('admin/smart_collections.json', $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/smart_collections.json", $params);
 
         $collection = array_map(function ($product) {
             return $this->unserializeModel($product, ShopifySmartCollection::class);
@@ -142,7 +145,7 @@ class SmartCollection extends CollectionEntity
     {
         $serializedModel = ['smart_collection' => $this->serializeModel($collection)];
 
-        $raw = $this->client->put("admin/smart_collections/{$collection->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/smart_collections/{$collection->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['smart_collection'], ShopifySmartCollection::class);
     }
@@ -154,7 +157,7 @@ class SmartCollection extends CollectionEntity
      */
     public function delete(ShopifySmartCollection $collection)
     {
-        return $this->client->delete("admin/smart_collections/{$collection->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/smart_collections/{$collection->getId()}.json");
     }
 
     /**
@@ -164,7 +167,7 @@ class SmartCollection extends CollectionEntity
      */
     public function count($filter = [])
     {
-        $raw = $this->client->get('admin/smart_collections/count.json', $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/smart_collections/count.json", $filter);
 
         return $raw['count'];
     }
@@ -176,7 +179,7 @@ class SmartCollection extends CollectionEntity
      */
     public function countByParams($filter = [])
     {
-        $raw = $this->client->get('admin/smart_collections/count.json', $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/smart_collections/count.json", $filter);
 
         return $raw['count'];
     }

--- a/src/Services/Theme.php
+++ b/src/Services/Theme.php
@@ -16,7 +16,7 @@ class Theme extends Base
     {
         $serializedModel = ['theme' => $this->serializeModel($shopifyTheme)];
 
-        $raw = $this->client->post('admin/themes.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/themes.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['theme'], ShopifyTheme::class);
     }
@@ -31,7 +31,7 @@ class Theme extends Base
         $id = $shopifyTheme->getId();
         $serializedModel = ['theme' => $this->serializeModel($shopifyTheme)];
 
-        $raw = $this->client->put("admin/themes/$id.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/themes/$id.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['theme'], ShopifyTheme::class);
     }
@@ -43,7 +43,7 @@ class Theme extends Base
      */
     public function getById($id)
     {
-        $raw = $this->client->get("admin/themes/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/themes/$id.json");
 
         return $this->unserializeModel($raw['theme'], ShopifyTheme::class);
     }
@@ -55,12 +55,15 @@ class Theme extends Base
     {
         $filter = ['role' => 'main'];
 
-        $raw = $this->client->get('admin/themes.json', $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/themes.json", $filter);
 
         return $this->unserializeModel($raw['themes'][0], ShopifyTheme::class);
     }
 
     /**
+     * @deprecated Use getByParams()
+     * @see getByParams()
+     *
      * @param array $filter
      *
      * @return Collection
@@ -68,6 +71,22 @@ class Theme extends Base
     public function getAll($filter = [])
     {
         $raw = $this->client->get('admin/themes.json', $filter);
+
+        $themes = array_map(function ($theme) {
+            return $this->unserializeModel($theme, ShopifyTheme::class);
+        }, $raw['themes']);
+
+        return new Collection($themes);
+    }
+
+    /**
+     * @param array $params
+     *
+     * @return Collection
+     */
+    public function getByParams($params = [])
+    {
+        $raw = $this->client->get("{$this->getApiBasePath()}/themes.json", $params);
 
         $themes = array_map(function ($theme) {
             return $this->unserializeModel($theme, ShopifyTheme::class);

--- a/src/Services/Transaction.php
+++ b/src/Services/Transaction.php
@@ -14,7 +14,7 @@ class Transaction extends Base
      */
     public function getByOrderId($orderId)
     {
-        $raw = $this->client->get("admin/orders/$orderId/transactions.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/orders/$orderId/transactions.json");
         $transactions = array_map(function ($transaction) {
             return $this->unserializeModel($transaction, ShopifyTransaction::class);
         }, $raw['transactions']);
@@ -31,7 +31,7 @@ class Transaction extends Base
     {
         $serializedModel = ['transaction' => $this->serializeModel($shopifyTransaction)];
 
-        $raw = $this->client->post("admin/orders/{$shopifyTransaction->getOrderId()}/transactions.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/orders/{$shopifyTransaction->getOrderId()}/transactions.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['transaction'], ShopifyTransaction::class);
     }

--- a/src/Services/UsageCharge.php
+++ b/src/Services/UsageCharge.php
@@ -16,7 +16,7 @@ class UsageCharge extends Base
     {
         $serializedModel = ['usage_charge' => $this->serializeModel($usageCharge)];
 
-        $raw = $this->client->post("admin/recurring_application_charges/$recurringChargeId/usage_charges.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/recurring_application_charges/$recurringChargeId/usage_charges.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['usage_charge'], ShopifyUsageCharge::class);
     }

--- a/src/Services/User.php
+++ b/src/Services/User.php
@@ -22,7 +22,7 @@ class User extends Base
      */
     public function getAll()
     {
-        $raw = $this->client->get('admin/users.json');
+        $raw = $this->client->get("{$this->getApiBasePath()}/users.json");
         $users = array_map(function ($user) {
             return $this->unserializeModel($user, ShopifyUser::class);
         }, $raw['users']);
@@ -35,7 +35,7 @@ class User extends Base
      */
     public function get($id)
     {
-        $raw = $this->client->get("admin/users/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/users/$id.json");
 
         return $this->unserializeModel($raw['user'], ShopifyUser::class);
     }
@@ -45,7 +45,7 @@ class User extends Base
      */
     public function current()
     {
-        $raw = $this->client->get('admin/users/current.json');
+        $raw = $this->client->get("{$this->getApiBasePath()}/users/current.json");
 
         return $this->unserializeModel($raw['user'], ShopifyUser::class);
     }

--- a/src/Services/Variant.php
+++ b/src/Services/Variant.php
@@ -19,7 +19,7 @@ class Variant extends Base
     {
         $serializedModel = ['variant' => $this->serializeModel($variant)];
 
-        $raw = $this->client->post("admin/products/{$product->getId()}/variants.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/products/{$product->getId()}/variants.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['variant'], ShopifyVariant::class);
     }
@@ -41,7 +41,7 @@ class Variant extends Base
      */
     public function getById($id)
     {
-        $raw = $this->client->get("admin/variants/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/variants/$id.json");
 
         return $this->unserializeModel($raw['variant'], ShopifyVariant::class);
     }
@@ -54,7 +54,7 @@ class Variant extends Base
      */
     public function getAllByProductId($productId, $filter = [])
     {
-        $raw = $this->client->get("admin/products/$productId/variants.json", $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/products/$productId/variants.json", $filter);
 
         $variants = array_map(function ($variant) {
             return $this->unserializeModel($variant, ShopifyVariant::class);
@@ -72,7 +72,7 @@ class Variant extends Base
     {
         $serializedModel = ['variant' => $this->serializeModel($variant)];
 
-        $raw = $this->client->put("admin/variants/{$variant->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/variants/{$variant->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['variant'], ShopifyVariant::class);
     }
@@ -85,7 +85,7 @@ class Variant extends Base
      */
     public function delete(ShopifyProduct $product, ShopifyVariant $variant)
     {
-        return $this->client->delete("admin/products/{$product->getId()}/variants/{$variant->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/products/{$product->getId()}/variants/{$variant->getId()}.json");
     }
 
     /**
@@ -98,7 +98,7 @@ class Variant extends Base
     {
         $serializedModel = ['metafield' => array_merge($this->serializeModel($metafield))];
 
-        $raw = $this->client->post("admin/variants/{$variant->getId()}/metafields.json", [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/variants/{$variant->getId()}/metafields.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['metafield'], ShopifyMetafield::class);
     }
@@ -113,7 +113,7 @@ class Variant extends Base
     {
         $serializedModel = ['metafield' => array_merge($this->serializeModel($metafield))];
 
-        $raw = $this->client->put("admin/variants/{$variant->getId()}/metafields/{$metafield->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/variants/{$variant->getId()}/metafields/{$metafield->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['metafield'], ShopifyMetafield::class);
     }
@@ -126,7 +126,7 @@ class Variant extends Base
      */
     public function getMetafields(ShopifyVariant $variant, $params = [])
     {
-        $raw = $this->client->get("admin/variants/{$variant->getId()}/metafields.json", $params);
+        $raw = $this->client->get("{$this->getApiBasePath()}/variants/{$variant->getId()}/metafields.json", $params);
 
         $metafields = array_map(function ($metafield) {
             return $this->unserializeModel($metafield, ShopifyMetafield::class);
@@ -143,7 +143,7 @@ class Variant extends Base
      */
     public function deleteMetafield(ShopifyVariant $variant, ShopifyMetafield $metafield)
     {
-        return $this->client->delete("admin/variants/{$variant->getId()}/metafields/{$metafield->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/variants/{$variant->getId()}/metafields/{$metafield->getId()}.json");
     }
 
     /**
@@ -153,6 +153,6 @@ class Variant extends Base
      */
     public function deleteMetafieldById(ShopifyMetafield $metafield)
     {
-        return $this->client->delete("admin/metafields/{$metafield->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/metafields/{$metafield->getId()}.json");
     }
 }

--- a/src/Services/Webhook.php
+++ b/src/Services/Webhook.php
@@ -16,7 +16,7 @@ class Webhook extends Base
     {
         $serializedModel = ['webhook' => $this->serializeModel($webhook)];
 
-        $raw = $this->client->post('admin/webhooks.json', [], $serializedModel);
+        $raw = $this->client->post("{$this->getApiBasePath()}/webhooks.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['webhook'], ShopifyWebhook::class);
     }
@@ -26,7 +26,7 @@ class Webhook extends Base
      */
     public function get()
     {
-        $raw = $this->client->get('admin/webhooks.json');
+        $raw = $this->client->get("{$this->getApiBasePath()}/webhooks.json");
 
         $webhooks = array_map(function ($webhook) {
             return $this->unserializeModel($webhook, ShopifyWebhook::class);
@@ -44,7 +44,7 @@ class Webhook extends Base
     {
         $serializedModel = ['webhook' => $this->serializeModel($webhook)];
 
-        $raw = $this->client->put("admin/webhooks/{$webhook->getId()}.json", [], $serializedModel);
+        $raw = $this->client->put("{$this->getApiBasePath()}/webhooks/{$webhook->getId()}.json", [], $serializedModel);
 
         return $this->unserializeModel($raw['webhook'], ShopifyWebhook::class);
     }
@@ -56,6 +56,6 @@ class Webhook extends Base
      */
     public function delete(ShopifyWebhook $webhook)
     {
-        return $this->client->delete("admin/webhooks/{$webhook->getId()}.json");
+        return $this->client->delete("{$this->getApiBasePath()}/webhooks/{$webhook->getId()}.json");
     }
 }


### PR DESCRIPTION
A follow up to this PR: https://github.com/bold-commerce/bold-shopify-toolkit/pull/117

- Updated the remainign Service classes to use the base API path from
  the Base class
- Deprecating getAll() methods that allow to pass a $page parameters in
  favour of the getByParams(). Added the getByParams to classes that did
not have them (Decided to do this to allow for consistency accross the
Service classes).