### PR TITLE
Ignoring inventory properties

### DIFF
--- a/src/Services/Variant.php
+++ b/src/Services/Variant.php
@@ -17,7 +17,7 @@ class Variant extends Base
      */
     public function create(ShopifyProduct $product, ShopifyVariant $variant)
     {
-        $serializedModel = ['variant' => $this->serializeModel($variant)];
+        $serializedModel = $this->serializeVariantCreateUpdate($variant);
 
         $raw = $this->client->post("{$this->getApiBasePath()}/products/{$product->getId()}/variants.json", [], $serializedModel);
 
@@ -70,7 +70,7 @@ class Variant extends Base
      */
     public function update(ShopifyVariant $variant)
     {
-        $serializedModel = ['variant' => $this->serializeModel($variant)];
+        $serializedModel = $this->serializeVariantCreateUpdate($variant);
 
         $raw = $this->client->put("{$this->getApiBasePath()}/variants/{$variant->getId()}.json", [], $serializedModel);
 
@@ -154,5 +154,21 @@ class Variant extends Base
     public function deleteMetafieldById(ShopifyMetafield $metafield)
     {
         return $this->client->delete("{$this->getApiBasePath()}/metafields/{$metafield->getId()}.json");
+    }
+
+    /**
+     * @param ShopifyVariant $variant
+     *
+     * @return array
+     */
+    public function serializeVariantCreateUpdate($variant)
+    {
+        $serializedModel = $this->serializeModel($variant);
+
+        unset($serializedModel['inventory_quantity']);
+        unset($serializedModel['old_inventory_quantity']);
+        unset($serializedModel['inventory_quantity_adjustment']);
+
+        return ['variant' => $serializedModel];
     }
 }

--- a/tests/VariantTest.php
+++ b/tests/VariantTest.php
@@ -43,6 +43,19 @@ class VariantTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * @test
+     */
+    public function ShopifyVariantWithoutInventorySerializesProperly()
+    {
+        $variantEntity = $this->createVariantEntity();
+
+        $expected = ['variant' => $this->getVariantArrayWithoutInventory()];
+        $actual = $this->variantService->serializeVariantCreateUpdate($variantEntity);
+
+        $this->assertEquals($expected, $actual);
+    }
+
     private function createVariantEntity()
     {
         /** @var ShopifyVariant $variantEntity */
@@ -106,6 +119,31 @@ class VariantTest extends \PHPUnit\Framework\TestCase
             'weight' => '3',
             'weight_unit' => 'kg',
             'old_inventory_quantity' => 0,
+            'requires_shipping' => true,
+        ];
+    }
+
+    private function getVariantArrayWithoutInventory()
+    {
+        return [
+            'id' => 5303296294944,
+            'product_id' => 440883118112,
+            'title' => 'Spooky',
+            'price' => 45.0,
+            'sku' => '',
+            'position' => 1,
+            'inventory_policy' => 'deny',
+            'fulfillment_service' => 'manual',
+            'option1' => 'Spooky',
+            'created_at' => '2017-12-08T13:35:42-05:00',
+            'updated_at' => '2017-12-21T09:49:41-05:00',
+            'taxable' => true,
+            'tax_code' => 'P000000',
+            'barcode' => '',
+            'grams' => 3000,
+            'inventory_item_id' => 5292496748576,
+            'weight' => '3',
+            'weight_unit' => 'kg',
             'requires_shipping' => true,
         ];
     }


### PR DESCRIPTION
Shopify latest API doesn't allow the following inventory properties to be updated with the variant endpoint: 
 - inventoryQuantity
 - oldInventoryQuantity
 - inventoryQuantityAdjustment

CSP still need to read this properties so that it's the reason of not serializing them. 