### PR TITLE
Update getting smart collection products to use correct endpoint

### DIFF
--- a/src/Services/SmartCollection.php
+++ b/src/Services/SmartCollection.php
@@ -76,7 +76,7 @@ class SmartCollection extends CollectionEntity
      */
     public function getById($id)
     {
-        $raw = $this->client->get("{$this->getApiBasePath()}/smart_collections/$id.json");
+        $raw = $this->client->get("{$this->getApiBasePath()}/collections/$id.json");
 
         return $this->unserializeModel($raw['smart_collection'], ShopifySmartCollection::class);
     }


### PR DESCRIPTION
* As of 2020-04 to get the the products in a smart collection you must use the collections resource
* https://shopify.dev/docs/admin-api/rest/reference/products/collection?api[version]=2020-04
* https://shopify.dev/docs/admin-api/rest/reference/products/smartcollection?api[version]=2020-04