### PR TITLE
Update getting smart collection products to use correct endpoint

### DIFF
--- a/src/Services/SmartCollection.php
+++ b/src/Services/SmartCollection.php
@@ -89,7 +89,7 @@ class SmartCollection extends CollectionEntity
      */
     public function getProductsBySmartCollectionId($id, $filter = [])
     {
-        $raw = $this->client->get("{$this->getApiBasePath()}/smart_collections/$id/products.json", $filter);
+        $raw = $this->client->get("{$this->getApiBasePath()}/collections/$id/products.json", $filter);
 
         $products = array_map(function ($product) {
             return $this->unserializeModel($product, ShopifyProduct::class);


### PR DESCRIPTION
* As of 2020-04 to get the the products in a smart collection you must use the collections resource
* https://shopify.dev/docs/admin-api/rest/reference/products/smartcollection?api[version]=2020-04
* https://shopify.dev/docs/admin-api/rest/reference/products/collect?api[version]=2020-04#index-2020-04