### PR TITLE
Add cancel order method

### DIFF
--- a/src/Models/CancelOrder.php
+++ b/src/Models/CancelOrder.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace BoldApps\ShopifyToolkit\Models;
+
+use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
+
+class CancelOrder implements Serializeable, \JsonSerializable
+{
+    use HasAttributesTrait;
+
+    /** @var float */
+    protected $amount;
+
+    /** @var string */
+    protected $currency;
+
+    /** @var string */
+    protected $reason;
+
+    /** @var bool */
+    protected $email;
+
+    /** @var Refund */
+    protected $refund;
+
+    /**
+     * @return float
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @param float $amount
+     */
+    public function setAmount($amount)
+    {
+        $this->amount = $amount;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+
+    /**
+     * @param string $currency
+     */
+    public function setCurrency($currency)
+    {
+        $this->currency = $currency;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReason()
+    {
+        return $this->reason;
+    }
+
+    /**
+     * @param string $reason
+     */
+    public function setReason($reason)
+    {
+        $this->reason = $reason;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param bool $email
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+    }
+
+    /**
+     * @return Refund
+     */
+    public function getRefund()
+    {
+        return $this->refund;
+    }
+
+    /**
+     * @param Refund $refund
+     */
+    public function setRefund($refund)
+    {
+        $this->refund = $refund;
+    }
+}

--- a/src/Services/Order.php
+++ b/src/Services/Order.php
@@ -2,9 +2,10 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Models\CancelOrder;
 use BoldApps\ShopifyToolkit\Models\Order as ShopifyOrder;
 use BoldApps\ShopifyToolkit\Models\TaxLine as TaxLineModel;
-use BoldApps\ShopifyToolkit\Models\OrderLineItem;
+use BoldApps\ShopifyToolkit\Models\OrderLineItem as OrderLineItemModel;
 use BoldApps\ShopifyToolkit\Services\TaxLine as TaxLineService;
 use BoldApps\ShopifyToolkit\Services\OrderLineItem as OrderLineItemService;
 use Illuminate\Support\Collection;
@@ -15,7 +16,7 @@ class Order extends CollectionEntity
     /** @var TaxLineService */
     protected $taxLineService;
 
-    /** @var OrderLineItem */
+    /** @var OrderLineItemModel */
     protected $lineItemService;
 
     /** @var array */
@@ -160,6 +161,20 @@ class Order extends CollectionEntity
     }
 
     /**
+     * @param int                $id
+     * @param CancelOrder | null $cancelOrder
+     *
+     * @return ShopifyOrder | object
+     */
+    public function cancel($id, $cancelOrder = null)
+    {
+        $serializedModel = $this->serializeModel($cancelOrder);
+        $raw = $this->client->post("{$this->getApiBasePath()}/orders/{$id}/cancel.json", [], $serializedModel);
+
+        return $this->unserializeModel($raw['order'], ShopifyOrder::class);
+    }
+
+    /**
      * @param $entities
      *
      * @return array|null
@@ -235,7 +250,7 @@ class Order extends CollectionEntity
 
         $lineItemService = &$this->lineItemService;
         $collection = array_map(function ($taxLine) use ($lineItemService) {
-            return $lineItemService->unserializeModel($taxLine, OrderLineItem::class);
+            return $lineItemService->unserializeModel($taxLine, OrderLineItemModel::class);
         }, $data);
 
         return new Collection($collection);

--- a/tests/Services/OrderTest.php
+++ b/tests/Services/OrderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace BoldApps\ShopifyToolkit\Test\Services;
+
+use BoldApps\ShopifyToolkit\Models\CancelOrder;
+use BoldApps\ShopifyToolkit\Services\Client;
+use BoldApps\ShopifyToolkit\Services\Order as OrderService;
+use BoldApps\ShopifyToolkit\Services\TaxLine as TaxLineService;
+use BoldApps\ShopifyToolkit\Services\OrderLineItem as OrderLineItemService;
+use PHPUnit\Framework\TestCase;
+
+class OrderTest extends TestCase
+{
+    /** @var OrderService */
+    private $orderService;
+
+    protected function setUp()
+    {
+        $client = $this->createMock(Client::class);
+        $taxLineService = new TaxLineService($client);
+        $orderLineItemService = new OrderLineItemService($client, $taxLineService);
+        $this->orderService = new OrderService($client, $taxLineService, $orderLineItemService);
+    }
+
+    public function testSerializeCancelOrder()
+    {
+        $cancelOrder = new CancelOrder();
+        $cancelOrder->setAmount(10.52);
+        $cancelOrder->setCurrency('CAD');
+        $cancelOrder->setReason('customer');
+        $cancelOrder->setEmail(true);
+
+        $expected = [
+            'amount' => 10.52,
+            'currency' => 'CAD',
+            'reason' => 'customer',
+            'email' => true,
+        ];
+
+        $actual = $this->orderService->serializeModel($cancelOrder);
+
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
Adding a new method to cancel an order according to : https://shopify.dev/docs/admin-api/rest/reference/orders/order?api[version]=2020-04