### PR TITLE
Throw an exception when cart clear request fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: |
             php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
             php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer invalid'; unlink('composer-setup.php'); } echo PHP_EOL;"
-            php composer-setup.php
+            php composer-setup.php --version=1.10.16
             php -r "unlink('composer-setup.php');"
 
       - run: php composer.phar install

--- a/src/Services/Cart.php
+++ b/src/Services/Cart.php
@@ -2,6 +2,7 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Cart\Item as CartItemModel;
 use BoldApps\ShopifyToolkit\Models\Cart\Cart as CartModel;
 use BoldApps\ShopifyToolkit\Models\Option as OptionModel;
@@ -43,6 +44,11 @@ class Cart extends Base
         $cookies = $this->getCartCookie($cartToken);
 
         $raw = $this->client->post('cart/clear.json', [], [], $cookies, $password, true);
+
+        if (empty($raw)) {
+            // The request to clear cart has failed, we are unable to take any further action on the cart
+            throw new ShopifyException('Received empty result while trying to clear cart');
+        }
 
         /** @var CartModel */
         $cart = $this->unserializeModel($raw, CartModel::class);

--- a/src/Services/Client.php
+++ b/src/Services/Client.php
@@ -198,9 +198,13 @@ class Client
 
             if ($password) {
                 $uri = new Uri(sprintf('https://%s/password', $domain));
-                $uri = $uri->withQuery(http_build_query(['password' => $password]));
-                $authRequest = new Request('GET', $uri);
-                $this->client->send($authRequest, $options);
+                $authResponse = $this->client->post(
+                    $uri,
+                    [
+                        'form_params' => ['password' => $password],
+                        'cookies' => $cookieJar,
+                    ]
+                );
             }
 
             foreach ($cookies as $cookie) {
@@ -210,7 +214,6 @@ class Client
             }
 
             $this->requestHookInterface->beforeRequest($request);
-
             $response = $this->client->send($request, $options);
 
             $result = \GuzzleHttp\json_decode((string) $response->getBody(), true);

--- a/tests/Services/CartTest.php
+++ b/tests/Services/CartTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace BoldApps\Common\Test\Services\Shopify;
+
+use BoldApps\ShopifyToolkit\Services\Cart;
+use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
+use BoldApps\ShopifyToolkit\Models\Cart\Cart as CartModel;
+use GuzzleHttp\Client as HttpClient;
+use PHPUnit\Framework\TestCase;
+
+class CartTest extends TestCase
+{
+    /** @var HttpClient */
+    private $client;
+
+    protected function setUp()
+    {
+        $this->client = $this->getMockBuilder(HttpClient::class)->getMock();
+    }
+
+    public function testClearCartWillClearAttributes()
+    {
+        $cart = $this->createCart();
+        $emptiedCart = $this->createCart(true);
+
+        $mockClient = $this->getMockBuilder(ShopifyClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cartService = new Cart($mockClient);
+
+        // Expect cart clear to be sent
+        $serializedCart = $cartService->serializeModel($cart);
+        $mockClient
+            ->expects($this->at(0))
+            ->method('post')
+            ->with('cart/clear.json', [], [], $this->anything(), null, true)
+            ->will($this->returnValue($serializedCart));
+
+        // Expect cart update to be sent with empty notes and empty attributes
+        $serializedEmptyCart = $cartService->serializeModel($emptiedCart);
+        $expectedCartData = [
+            'note' => '',
+            'attributes' => $emptiedCart->getAttributes(),
+        ];
+        $mockClient
+            ->expects($this->at(1))
+            ->method('post')
+            ->with('cart/update.json', [], $expectedCartData, $this->anything(), null, true)
+            ->will($this->returnValue($serializedEmptyCart));
+
+        $cartToken = 'nice-cart-token';
+        $clearedCart = $cartService->clear($cartToken);
+    }
+
+    public function testClearCartWithPassword()
+    {
+        $cart = $this->createCart();
+        $emptiedCart = $this->createCart(true);
+
+        $mockClient = $this->getMockBuilder(ShopifyClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cartService = new Cart($mockClient);
+
+        // Expect cart clear to be sent with password
+        $serializedCart = $cartService->serializeModel($cart);
+        $mockClient
+            ->expects($this->at(0))
+            ->method('post')
+            ->with('cart/clear.json', [], [], $this->anything(), 'password', true)
+            ->will($this->returnValue($serializedCart));
+
+        $serializedEmptyCart = $cartService->serializeModel($emptiedCart);
+        $mockClient
+            ->expects($this->at(1))
+            ->method('post')
+            ->will($this->returnValue($serializedEmptyCart));
+
+        $cartToken = 'nice-cart-token';
+        $clearedCart = $cartService->clear($cartToken, 'password');
+    }
+
+    private function createCart($setValuesToEmpty = false)
+    {
+        $cart = new CartModel();
+
+        if ($setValuesToEmpty) {
+            $cart->setNote('');
+            $cart->setAttributes(['attribute1' => '']);
+        } else {
+            $cart->setNote('note');
+            $cart->setAttributes(['attribute1' => 'value1']);
+        }
+
+        $cart->setTotalDiscount(3);
+        $cart->setTotalWeight(4);
+        $cart->setItemCount(0);
+        $cart->setTotalPrice(8);
+        $cart->setOriginalTotalPrice(5);
+        $cart->setToken('token');
+        $cart->setRequiresShipping(true);
+
+        return $cart;
+    }
+}

--- a/tests/Services/ClientTest.php
+++ b/tests/Services/ClientTest.php
@@ -127,23 +127,23 @@ class ClientTest extends TestCase
     {
         $expectedHeaders = [
             'Content-Length' => [
-                    0 => '4',
-                ],
+                0 => '4',
+            ],
             'Host' => [
-                    0 => 'fight-club.myshopify.com',
-                ],
+                0 => 'fight-club.myshopify.com',
+            ],
             'X-Shopify-Access-Token' => [
-                    0 => '',
-                ],
+                0 => '',
+            ],
             'Content-Type' => [
-                    0 => 'application/json',
-                ],
+                0 => 'application/json',
+            ],
             'charset' => [
-                    0 => 'utf-8',
-                ],
+                0 => 'utf-8',
+            ],
             'X-Shopify-Api-Features' => [
-                    0 => 'creates-test-orders',
-                ],
+                0 => 'creates-test-orders',
+            ],
         ];
 
         // mock http client
@@ -170,6 +170,53 @@ class ClientTest extends TestCase
             '{}',
             [],
             null,
+            false,
+            ['X-Shopify-Api-Features' => 'creates-test-orders']
+        );
+
+        /* @var Request $sentRequest */
+        $sentRequest = $container[0]['request'];
+        $sentHeaders = $sentRequest->getHeaders();
+        //User agent varies per system.
+        unset($sentHeaders['User-Agent']);
+
+        $this->assertEquals($expectedHeaders, $sentHeaders);
+    }
+
+    public function testPostWithPasswordSendsPasswordAuthenticationRequest()
+    {
+        $expectedHeaders = [
+            'Content-Length' => [0 => '17'],
+            'Host' => [0 => 'fight-club.myshopify.com'],
+            'Content-Type' => [0 => 'application/x-www-form-urlencoded'],
+        ];
+
+        // mock http client
+        $mock = new MockHandler([new Response(200)]);
+        $container = [];
+        $history = Middleware::history($container);
+        $handlerStack = HandlerStack::create($mock);
+        // Add the history middleware to the handler stack.
+        $handlerStack->push($history);
+        $mockHttpClient = new \GuzzleHttp\Client(['handler' => $handlerStack]);
+
+        $this->mockShopBaseInfo->expects($this->any())
+            ->method('getMyShopifyDomain')
+            ->will($this->returnValue($this->myShopifyDomain));
+
+        $this->client = new Client(
+            $this->mockShopBaseInfo,
+            $this->mockShopAccessInfo,
+            $mockHttpClient,
+            $this->mockRequestHookInterface
+        );
+
+        $raw = $this->client->post(
+            'admin/orders.json',
+            [],
+            '{}',
+            [],
+            'password',
             false,
             ['X-Shopify-Api-Features' => 'creates-test-orders']
         );


### PR DESCRIPTION
When a Shopify shop has password enabled Shopify replies with status
code 200 and an html page requesting the password. When this happens
we get a null value when json_decode fails. This is an invalid cart
so we throw a pretty generic ShopifyException so the caller can handle
the error.