### PR TITLE
Adding responses to ShopifyExceptions

### DIFF
--- a/src/Exceptions/ShopifyException.php
+++ b/src/Exceptions/ShopifyException.php
@@ -4,4 +4,25 @@ namespace BoldApps\ShopifyToolkit\Exceptions;
 
 class ShopifyException extends \Exception
 {
+    private $response;
+
+    /**
+     * @return mixed
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * @param mixed $response
+     *
+     * @return ShopifyException
+     */
+    public function setResponse($response)
+    {
+        $this->response = $response;
+
+        return $this;
+    }
 }

--- a/src/Services/Client.php
+++ b/src/Services/Client.php
@@ -233,17 +233,17 @@ class Client
 
             switch ($response->getStatusCode()) {
                 case 400:
-                    throw new BadRequestException($e->getMessage());
+                    throw (new BadRequestException($e->getMessage()))->setResponse($response);
                 case 401:
-                    throw new UnauthorizedException($e->getMessage());
+                    throw (new UnauthorizedException($e->getMessage()))->setResponse($response);
                 case 404:
-                    throw new NotFoundException($e->getMessage());
+                    throw (new NotFoundException($e->getMessage()))->setResponse($response);
                 case 406:
-                    throw new NotAcceptableException($e->getMessage());
+                    throw (new NotAcceptableException($e->getMessage()))->setResponse($response);
                 case 422:
-                    throw new UnprocessableEntityException($e->getMessage());
+                    throw (new UnprocessableEntityException($e->getMessage()))->setResponse($response);
                 case 429:
-                    throw new TooManyRequestsException($e->getMessage());
+                    throw (new TooManyRequestsException($e->getMessage()))->setResponse($response);
                 default:
                     throw $e;
             }


### PR DESCRIPTION
Adding responses from the ShopifyExceptions to grab the x-request-id that can be provided to Shopify to further investigate failed requests.