### PR TITLE
Add productsCount attribute to SmartCollections

### DIFF
--- a/src/Models/SmartCollection.php
+++ b/src/Models/SmartCollection.php
@@ -46,6 +46,9 @@ class SmartCollection implements Serializeable, \JsonSerializable
     /** @var array */
     protected $image;
 
+    /** @var int|null */
+    protected $productsCount;
+
     /**
      * @return int
      */
@@ -103,7 +106,7 @@ class SmartCollection implements Serializeable, \JsonSerializable
     }
 
     /**
-     * @return null|string
+     * @return string|null
      */
     public function getTemplateSuffix()
     {
@@ -111,7 +114,7 @@ class SmartCollection implements Serializeable, \JsonSerializable
     }
 
     /**
-     * @return null|string
+     * @return string|null
      */
     public function getPublishedScope()
     {
@@ -140,6 +143,14 @@ class SmartCollection implements Serializeable, \JsonSerializable
     public function getImage()
     {
         return $this->image;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getProductsCount()
+    {
+        return $this->productsCount;
     }
 
     /**
@@ -236,5 +247,13 @@ class SmartCollection implements Serializeable, \JsonSerializable
     public function setImage($image)
     {
         $this->image = $image;
+    }
+
+    /**
+     * @param int|null productsCount
+     */
+    public function setProductsCount($productsCount)
+    {
+        $this->productsCount = $productsCount;
     }
 }

--- a/tests/SmartCollectionTest.php
+++ b/tests/SmartCollectionTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Models\SmartCollection as ShopifySmartCollection;
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\SmartCollection as SmartCollectionService;
 use BoldApps\ShopifyToolkit\Services\SmartCollectionRule as SmartCollectionRuleService;
 
@@ -67,6 +67,7 @@ class SmartCollectionTest extends \PHPUnit\Framework\TestCase
             "published_at": "2018-01-08T10:56:11-06:00",
             "sort_order": "best-selling",
             "template_suffix": null,
+            "products_count": 2,
             "disjunctive": false,
             "rules": [
                 {
@@ -108,6 +109,7 @@ class SmartCollectionTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
             'published_scope' => 'web',
+            'products_count' => 2,
         ];
     }
 }


### PR DESCRIPTION
* This attribute list the number of products in a smartCollection
* Shopify Docs https://shopify.dev/docs/admin-api/rest/reference/products/smartcollection?api%5Bversion%5D=2020-01#show-2020-01