### PR TITLE
Transaction Source Property

### DIFF
--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -63,6 +63,9 @@ class Transaction implements Serializeable, \JsonSerializable
     /** @var string */
     public $sourceName;
 
+    /** @var string */
+    public $source;
+
     /** @var float */
     public $maximumRefundable;
 
@@ -352,6 +355,22 @@ class Transaction implements Serializeable, \JsonSerializable
     public function setSourceName($sourceName)
     {
         $this->sourceName = $sourceName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSource()
+    {
+        return $this->source;
+    }
+
+    /**
+     * @param string $source
+     */
+    public function setSource($source)
+    {
+        $this->source = $source;
     }
 
     /**


### PR DESCRIPTION
Adding the source property to the transaction model. This is necessary to create a capture transaction with status pending.

It's buried in the docs but [it's there](https://shopify.dev/docs/admin-api/rest/reference/orders/transaction#create-2020-10).

<img width="825" alt="Screen Shot 2021-01-07 at 3 47 48 PM" src="https://user-images.githubusercontent.com/118674/103948699-d7a92080-50ff-11eb-8d02-b88346189eaf.png">
