### PR TITLE
Add price rule prerequisite to entitlement purchase

### DIFF
--- a/src/Models/PriceRule.php
+++ b/src/Models/PriceRule.php
@@ -61,6 +61,9 @@ class PriceRule implements Serializeable, \JsonSerializable
     protected $prerequisiteToEntitlementQuantityRatio;
 
     /** @var array */
+    protected $prerequisiteToEntitlementPurchase;
+
+    /** @var array */
     protected $prerequisiteVariantIds;
 
     /** @var array */
@@ -358,11 +361,27 @@ class PriceRule implements Serializeable, \JsonSerializable
     }
 
     /**
+     * @return array
+     */
+    public function getPrerequisiteToEntitlementPurchase()
+    {
+        return $this->prerequisiteToEntitlementPurchase;
+    }
+
+    /**
      * @param array $prerequisiteToEntitlementQuantityRatio
      */
     public function setPrerequisiteToEntitlementQuantityRatio($prerequisiteToEntitlementQuantityRatio)
     {
         $this->prerequisiteToEntitlementQuantityRatio = $prerequisiteToEntitlementQuantityRatio;
+    }
+
+    /**
+     * @param array $prerequisiteToEntitlementPurchase
+     */
+    public function setPrerequisiteToEntitlementPurchase($prerequisiteToEntitlementPurchase)
+    {
+        $this->prerequisiteToEntitlementPurchase = $prerequisiteToEntitlementPurchase;
     }
 
     /**

--- a/tests/PriceRuleTest.php
+++ b/tests/PriceRuleTest.php
@@ -76,6 +76,9 @@ class PriceRuleTest extends \PHPUnit\Framework\TestCase
                 "prerequisite_quantity": 1,
                 "entitled_quantity": 2
             },
+            "prerequisite_to_entitlement_purchase": {
+              "prerequisite_amount": 20
+            },
             "title": "WINTER SALE"
         }';
     }
@@ -109,6 +112,7 @@ class PriceRuleTest extends \PHPUnit\Framework\TestCase
             'prerequisite_quantity_range' => array('greater_than_or_equal_to' => 5),
             'prerequisite_shipping_price_range' => array('less_than_or_equal_to' => '17.0'),
             'prerequisite_to_entitlement_quantity_ratio' => array('prerequisite_quantity' => 1, 'entitled_quantity' => 2),
+            'prerequisite_to_entitlement_purchase' => array('prerequisite_amount' => 20),
             'title' => 'WINTER SALE',
         ];
     }


### PR DESCRIPTION
- Shopify contains price rules that allow a Buy-X-Get-Y discount where X
  is a purchase amount rather than a quantity amount.
- The Shopify Toolkit did not support this... until now!
- Added a new field `prerequisiteToEntitlementPurchase` to the
  PriceRules model, along with a getter/setter.
- Updated the PriceRule test to show the proper
  serialization/deserialization of the PriceRules model with the
newly-added field.