### PR TITLE
Update Bold-Shopify-Toolkit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/php:5.6.37-apache-jessie as base
+FROM circleci/php:7.4.15-apache-jessie as base
 
 FROM base
 ARG cache=1

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.2",
-        "illuminate/support": "5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || ^6 || ^7"
+        "guzzlehttp/guzzle": "^6.2 || ^7.1",
+        "illuminate/support": "5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || ^6 || ^7 || ^8"
     },
     "autoload": {
         "psr-4": {
@@ -37,7 +37,7 @@
         ]
     },
     "require-dev": {
-        "phpunit/phpunit": "5.5.*",
-        "friendsofphp/php-cs-fixer": "~2.13"
+        "phpunit/phpunit": "^8",
+        "friendsofphp/php-cs-fixer": "^2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,37 +4,41 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a37a6b3562f803d4c0fff4d941cdd60a",
+    "content-hash": "4a7c25b8d32c6eaaf7b0c724c50c522b",
     "packages": [
         {
             "name": "doctrine/inflector",
-            "version": "v1.1.0",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
+                "reference": "9cf661f4eb38f7c881cac67c75ea9b00bf97b210"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
-                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/9cf661f4eb38f7c881cac67c75ea9b00bf97b210",
+                "reference": "9cf661f4eb38f7c881cac67c75ea9b00bf97b210",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*"
+                "doctrine/coding-standard": "^7.0",
+                "phpstan/phpstan": "^0.11",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Inflector\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Inflector\\": "lib/Doctrine/Inflector"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -43,16 +47,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -63,53 +67,84 @@
                     "email": "schmittjoh@gmail.com"
                 }
             ],
-            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
-            "homepage": "http://www.doctrine-project.org",
+            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
+            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
             "keywords": [
                 "inflection",
-                "pluralize",
-                "singularize",
-                "string"
+                "inflector",
+                "lowercase",
+                "manipulation",
+                "php",
+                "plural",
+                "singular",
+                "strings",
+                "uppercase",
+                "words"
             ],
-            "time": "2015-11-06T14:35:42+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T15:13:26+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.2",
+            "version": "7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
+                "reference": "0aa74dfb41ae110835923ef10a9d803a22d50e79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
-                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/0aa74dfb41ae110835923ef10a9d803a22d50e79",
+                "reference": "0aa74dfb41ae110835923ef10a9d803a22d50e79",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.3.1",
-                "php": ">=5.5"
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.4",
+                "guzzlehttp/psr7": "^1.7",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0",
-                "psr/log": "^1.0"
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.2-dev"
+                    "dev-master": "7.1-dev"
                 }
             },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
-                }
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -120,6 +155,11 @@
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
                 }
             ],
             "description": "Guzzle is a PHP HTTP client library",
@@ -130,30 +170,50 @@
                 "framework",
                 "http",
                 "http client",
+                "psr-18",
+                "psr-7",
                 "rest",
                 "web service"
             ],
-            "time": "2016-10-08T15:01:37+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/alexeyshockov",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/gmponos",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-10T11:47:56+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "v1.3.1",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
-                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.0"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0"
+                "symfony/phpunit-bridge": "^4.4 || ^5.1"
             },
             "type": "library",
             "extra": {
@@ -184,36 +244,41 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-12-20T10:07:11+00:00"
+            "time": "2021-03-07T09:25:29+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.3.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
+                "reference": "53330f47520498c0ae1f61f7e2c90f55690c06a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
-                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/53330f47520498c0ae1f61f7e2c90f55690c06a3",
+                "reference": "53330f47520498c0ae1f61f7e2c90f55690c06a3",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "psr/http-message": "~1.0"
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.7-dev"
                 }
             },
             "autoload": {
@@ -233,38 +298,98 @@
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
                 }
             ],
-            "description": "PSR-7 message implementation",
+            "description": "PSR-7 message implementation that also provides common utility methods",
             "keywords": [
                 "http",
                 "message",
+                "psr-7",
+                "request",
+                "response",
                 "stream",
-                "uri"
+                "uri",
+                "url"
             ],
-            "time": "2016-06-24T23:00:38+00:00"
+            "time": "2020-09-30T07:37:11+00:00"
         },
         {
-            "name": "illuminate/contracts",
-            "version": "v5.3.23",
+            "name": "illuminate/collections",
+            "version": "v8.31.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/illuminate/contracts.git",
-                "reference": "ce5d73c6015b2054d32f3f8530767847b358ae4e"
+                "url": "https://github.com/illuminate/collections.git",
+                "reference": "ecc881c6dce66e22f2c236374f342d41c7ebeb67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/ce5d73c6015b2054d32f3f8530767847b358ae4e",
-                "reference": "ce5d73c6015b2054d32f3f8530767847b358ae4e",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/ecc881c6dce66e22f2c236374f342d41c7ebeb67",
+                "reference": "ecc881c6dce66e22f2c236374f342d41c7ebeb67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.4"
+                "illuminate/contracts": "^8.0",
+                "illuminate/macroable": "^8.0",
+                "php": "^7.3|^8.0"
+            },
+            "suggest": {
+                "symfony/var-dumper": "Required to use the dump method (^5.1.4)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3-dev"
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                },
+                "files": [
+                    "helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Collections package.",
+            "homepage": "https://laravel.com",
+            "time": "2021-03-02T13:34:56+00:00"
+        },
+        {
+            "name": "illuminate/contracts",
+            "version": "v8.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/contracts.git",
+                "reference": "9c7a9868d7485a82663d67109429094c8e4ed56d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/9c7a9868d7485a82663d67109429094c8e4ed56d",
+                "reference": "9c7a9868d7485a82663d67109429094c8e4ed56d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3|^8.0",
+                "psr/container": "^1.0",
+                "psr/simple-cache": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
                 }
             },
             "autoload": {
@@ -284,41 +409,90 @@
             ],
             "description": "The Illuminate Contracts package.",
             "homepage": "https://laravel.com",
-            "time": "2016-09-26T20:36:27+00:00"
+            "time": "2021-02-26T13:17:03+00:00"
         },
         {
-            "name": "illuminate/support",
-            "version": "v5.3.23",
+            "name": "illuminate/macroable",
+            "version": "v8.31.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/illuminate/support.git",
-                "reference": "050d0ed3e1c0e1d129d73b2eaa14044e46a66f77"
+                "url": "https://github.com/illuminate/macroable.git",
+                "reference": "300aa13c086f25116b5f3cde3ca54ff5c822fb05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/050d0ed3e1c0e1d129d73b2eaa14044e46a66f77",
-                "reference": "050d0ed3e1c0e1d129d73b2eaa14044e46a66f77",
+                "url": "https://api.github.com/repos/illuminate/macroable/zipball/300aa13c086f25116b5f3cde3ca54ff5c822fb05",
+                "reference": "300aa13c086f25116b5f3cde3ca54ff5c822fb05",
                 "shasum": ""
             },
             "require": {
-                "doctrine/inflector": "~1.0",
-                "ext-mbstring": "*",
-                "illuminate/contracts": "5.3.*",
-                "paragonie/random_compat": "~1.4|~2.0",
-                "php": ">=5.6.4"
-            },
-            "replace": {
-                "tightenco/collect": "self.version"
-            },
-            "suggest": {
-                "illuminate/filesystem": "Required to use the composer class (5.2.*).",
-                "symfony/process": "Required to use the composer class (3.1.*).",
-                "symfony/var-dumper": "Required to use the dd function (3.1.*)."
+                "php": "^7.3|^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3-dev"
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Macroable package.",
+            "homepage": "https://laravel.com",
+            "time": "2020-10-27T15:20:30+00:00"
+        },
+        {
+            "name": "illuminate/support",
+            "version": "v8.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/support.git",
+                "reference": "978e64ffb68189b70fea77e4d401f43e88fa54ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/978e64ffb68189b70fea77e4d401f43e88fa54ca",
+                "reference": "978e64ffb68189b70fea77e4d401f43e88fa54ca",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^1.4|^2.0",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "illuminate/collections": "^8.0",
+                "illuminate/contracts": "^8.0",
+                "illuminate/macroable": "^8.0",
+                "nesbot/carbon": "^2.31",
+                "php": "^7.3|^8.0",
+                "voku/portable-ascii": "^1.4.8"
+            },
+            "conflict": {
+                "tightenco/collect": "<5.5.33"
+            },
+            "suggest": {
+                "illuminate/filesystem": "Required to use the composer class (^8.0).",
+                "league/commonmark": "Required to use Str::markdown() and Stringable::markdown() (^1.3).",
+                "ramsey/uuid": "Required to use Str::uuid() (^4.0).",
+                "symfony/process": "Required to use the composer class (^5.1.4).",
+                "symfony/var-dumper": "Required to use the dd function (^5.1.4).",
+                "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.2)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
                 }
             },
             "autoload": {
@@ -341,36 +515,62 @@
             ],
             "description": "The Illuminate Support package.",
             "homepage": "https://laravel.com",
-            "time": "2016-11-03T15:25:28+00:00"
+            "time": "2021-03-04T14:09:31+00:00"
         },
         {
-            "name": "paragonie/random_compat",
-            "version": "v2.0.4",
+            "name": "nesbot/carbon",
+            "version": "2.46.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e"
+                "url": "https://github.com/briannesbitt/Carbon.git",
+                "reference": "2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
-                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4",
+                "reference": "2fd2c4a77d58a4e95234c8a61c5df1f157a91bf4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2.0"
+                "ext-json": "*",
+                "php": "^7.1.8 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/translation": "^3.4 || ^4.0 || ^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*|5.*"
+                "doctrine/orm": "^2.7",
+                "friendsofphp/php-cs-fixer": "^2.14 || ^3.0",
+                "kylekatarnls/multi-tester": "^2.0",
+                "phpmd/phpmd": "^2.9",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.54",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.14",
+                "squizlabs/php_codesniffer": "^3.4"
             },
-            "suggest": {
-                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-            },
+            "bin": [
+                "bin/carbon"
+            ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev",
+                    "dev-3.x": "3.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Carbon\\Laravel\\ServiceProvider"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
             "autoload": {
-                "files": [
-                    "lib/random.php"
-                ]
+                "psr-4": {
+                    "Carbon\\": "src/Carbon/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -378,18 +578,126 @@
             ],
             "authors": [
                 {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com"
+                    "name": "Brian Nesbitt",
+                    "email": "brian@nesbot.com",
+                    "homepage": "http://nesbot.com"
+                },
+                {
+                    "name": "kylekatarnls",
+                    "homepage": "http://github.com/kylekatarnls"
                 }
             ],
-            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "description": "An API extension for DateTime that supports 281 different languages.",
+            "homepage": "http://carbon.nesbot.com",
             "keywords": [
-                "csprng",
-                "pseudorandom",
-                "random"
+                "date",
+                "datetime",
+                "time"
             ],
-            "time": "2016-11-07T23:38:38+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/Carbon",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-24T17:30:44+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2021-03-05T17:36:06+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "time": "2020-06-29T06:28:15+00:00"
         },
         {
             "name": "psr/http-message",
@@ -440,34 +748,514 @@
                 "response"
             ],
             "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-22T09:19:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v5.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "74b0353ab34ff4cca827a2cf909e325d96815e60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/74b0353ab34ff4cca827a2cf909e325d96815e60",
+                "reference": "74b0353ab34ff4cca827a2cf909e325d96815e60",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/translation-contracts": "^2.3"
+            },
+            "conflict": {
+                "symfony/config": "<4.4",
+                "symfony/dependency-injection": "<5.0",
+                "symfony/http-kernel": "<5.0",
+                "symfony/twig-bundle": "<5.0",
+                "symfony/yaml": "<4.4"
+            },
+            "provide": {
+                "symfony/translation-implementation": "2.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/console": "^4.4|^5.0",
+                "symfony/dependency-injection": "^5.0",
+                "symfony/finder": "^4.4|^5.0",
+                "symfony/http-kernel": "^5.0",
+                "symfony/intl": "^4.4|^5.0",
+                "symfony/service-contracts": "^1.1.2|^2",
+                "symfony/yaml": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log-implementation": "To use logging capability in translator",
+                "symfony/config": "",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to internationalize your application",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-04T15:41:09+00:00"
+        },
+        {
+            "name": "symfony/translation-contracts",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "e2eaa60b558f26a4b0354e1bbb25636efaaad105"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/e2eaa60b558f26a4b0354e1bbb25636efaaad105",
+                "reference": "e2eaa60b558f26a4b0354e1bbb25636efaaad105",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5"
+            },
+            "suggest": {
+                "symfony/translation-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-28T13:05:58+00:00"
+        },
+        {
+            "name": "voku/portable-ascii",
+            "version": "1.5.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/voku/portable-ascii.git",
+                "reference": "80953678b19901e5165c56752d087fc11526017c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/80953678b19901e5165c56752d087fc11526017c",
+                "reference": "80953678b19901e5165c56752d087fc11526017c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+            },
+            "suggest": {
+                "ext-intl": "Use Intl for transliterator_transliterate() support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "voku\\": "src/voku/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Moelleken",
+                    "homepage": "http://www.moelleken.org/"
+                }
+            ],
+            "description": "Portable ASCII library - performance optimized (ascii) string functions for php.",
+            "homepage": "https://github.com/voku/portable-ascii",
+            "keywords": [
+                "ascii",
+                "clean",
+                "php"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/moelleken",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/voku",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/portable-ascii",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://www.patreon.com/voku",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/voku/portable-ascii",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-12T00:07:28+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "composer/semver",
-            "version": "1.4.2",
+            "version": "3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
+                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
-                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "url": "https://api.github.com/repos/composer/semver/zipball/a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
+                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0"
+                "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5 || ^5.0.5",
-                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+                "phpstan/phpstan": "^0.12.54",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -503,28 +1291,42 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2016-08-30T16:08:34+00:00"
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T08:59:24+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.3.0",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c"
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/b8e9745fb9b06ea6664d8872c4505fb16df4611c",
-                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0",
+                "php": "^5.3.2 || ^7.0 || ^8.0",
                 "psr/log": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
             },
             "type": "library",
             "autoload": {
@@ -542,41 +1344,53 @@
                     "email": "john-stevenson@blueyonder.co.uk"
                 }
             ],
-            "description": "Restarts a process without xdebug.",
+            "description": "Restarts a process without Xdebug.",
             "keywords": [
                 "Xdebug",
                 "performance"
             ],
-            "time": "2018-08-31T19:07:57+00:00"
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T08:04:11+00:00"
         },
         {
             "name": "doctrine/annotations",
-            "version": "v1.4.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97"
+                "reference": "b17c5014ef81d212ac539f07a1001832df1b6d3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/54cacc9b81758b14e3ce750f205a393d52339e97",
-                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/b17c5014ef81d212ac539f07a1001832df1b6d3b",
+                "reference": "b17c5014ef81d212ac539f07a1001832df1b6d3b",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "1.*",
-                "php": "^5.6 || ^7.0"
+                "ext-tokenizer": "*",
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "^5.7"
+                "doctrine/coding-standard": "^6.0 || ^8.1",
+                "phpstan/phpstan": "^0.12.20",
+                "phpunit/phpunit": "^7.5 || ^9.1.5"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
@@ -588,16 +1402,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -609,44 +1423,41 @@
                 }
             ],
             "description": "Docblock Annotations Parser",
-            "homepage": "http://www.doctrine-project.org",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
             "keywords": [
                 "annotations",
                 "docblock",
                 "parser"
             ],
-            "time": "2017-02-24T16:22:25+00:00"
+            "time": "2021-02-21T21:00:45+00:00"
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^8.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -660,43 +1471,62 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-10T18:47:58+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "v1.0.1",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
-                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/e864bbf5904cb8f5bb334f99209b48018522f042",
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Lexer\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -705,76 +1535,94 @@
             ],
             "authors": [
                 {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
                     "name": "Guilherme Blanco",
                     "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Johannes Schmitt",
                     "email": "schmittjoh@gmail.com"
                 }
             ],
-            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
-            "homepage": "http://www.doctrine-project.org",
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
             "keywords": [
+                "annotations",
+                "docblock",
                 "lexer",
-                "parser"
+                "parser",
+                "php"
             ],
-            "time": "2014-09-09T13:34:57+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-25T17:44:05+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.13.0",
+            "version": "v2.18.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "7136aa4e0c5f912e8af82383775460d906168a10"
+                "reference": "18f8c9d184ba777380794a389fabc179896ba913"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/7136aa4e0c5f912e8af82383775460d906168a10",
-                "reference": "7136aa4e0c5f912e8af82383775460d906168a10",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/18f8c9d184ba777380794a389fabc179896ba913",
+                "reference": "18f8c9d184ba777380794a389fabc179896ba913",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^1.4",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^1.2",
                 "doctrine/annotations": "^1.2",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || >=7.0 <7.3",
+                "php": "^5.6 || ^7.0 || ^8.0",
                 "php-cs-fixer/diff": "^1.3",
-                "symfony/console": "^3.2 || ^4.0",
-                "symfony/event-dispatcher": "^3.0 || ^4.0",
-                "symfony/filesystem": "^3.0 || ^4.0",
-                "symfony/finder": "^3.0 || ^4.0",
-                "symfony/options-resolver": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.43 || ^4.1.6 || ^5.0",
+                "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
+                "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
+                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
+                "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
                 "symfony/polyfill-php70": "^1.0",
                 "symfony/polyfill-php72": "^1.4",
-                "symfony/process": "^3.0 || ^4.0",
-                "symfony/stopwatch": "^3.0 || ^4.0"
-            },
-            "conflict": {
-                "hhvm": "*"
+                "symfony/process": "^3.0 || ^4.0 || ^5.0",
+                "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
             },
             "require-dev": {
-                "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
                 "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.1",
+                "keradus/cli-executor": "^1.4",
                 "mikey179/vfsstream": "^1.6",
-                "php-coveralls/php-coveralls": "^2.1",
+                "php-coveralls/php-coveralls": "^2.4.2",
                 "php-cs-fixer/accessible-object": "^1.0",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.0.1",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.0.1",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1",
-                "phpunitgoodpractices/traits": "^1.5.1",
-                "symfony/phpunit-bridge": "^4.0"
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
+                "phpspec/prophecy-phpunit": "^1.1 || ^2.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.13 || ^9.5",
+                "phpunitgoodpractices/polyfill": "^1.5",
+                "phpunitgoodpractices/traits": "^1.9.1",
+                "sanmai/phpunit-legacy-adapter": "^6.4 || ^8.2.1",
+                "symfony/phpunit-bridge": "^5.2.1",
+                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
             },
             "suggest": {
-                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters.",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
                 "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
@@ -783,11 +1631,6 @@
                 "php-cs-fixer"
             ],
             "type": "application",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.13-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
@@ -801,6 +1644,7 @@
                     "tests/Test/IntegrationCaseFactory.php",
                     "tests/Test/IntegrationCaseFactoryInterface.php",
                     "tests/Test/InternalIntegrationCaseFactory.php",
+                    "tests/Test/IsIdenticalConstraint.php",
                     "tests/TestCase.php"
                 ]
             },
@@ -810,50 +1654,62 @@
             ],
             "authors": [
                 {
-                    "name": "Dariusz Rumiński",
-                    "email": "dariusz.ruminski@gmail.com"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2018-08-23T13:15:44+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-26T00:22:21+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.5.5",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108"
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/399c1f9781e222f6eb6cc238796f5200d1b7f108",
-                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^7.1 || ^8.0"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
-                }
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -861,27 +1717,136 @@
                 "object",
                 "object graph"
             ],
-            "time": "2016-10-31T17:19:45+00:00"
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T09:40:50+00:00"
         },
         {
-            "name": "php-cs-fixer/diff",
-            "version": "v1.3.0",
+            "name": "phar-io/manifest",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHP-CS-Fixer/diff.git",
-                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756"
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/78bb099e9c16361126c86ce82ec4405ebab8e756",
-                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2020-06-27T14:33:11+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2021-02-23T14:00:09+00:00"
+        },
+        {
+            "name": "php-cs-fixer/diff",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/diff.git",
+                "reference": "dbd31aeb251639ac0b9e7e29405c1441907f5759"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/dbd31aeb251639ac0b9e7e29405c1441907f5759",
+                "reference": "dbd31aeb251639ac0b9e7e29405c1441907f5759",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3 || ^7.0",
                 "symfony/process": "^3.3"
             },
             "type": "library",
@@ -896,12 +1861,12 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 },
                 {
                     "name": "SpacePossum"
@@ -912,39 +1877,34 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2018-02-15T16:58:55+00:00"
+            "time": "2020-10-14T08:39:05+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -966,38 +1926,41 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2020-06-27T09:03:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.1",
+            "version": "5.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
-                "webmozart/assert": "^1.0"
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "mockery/mockery": "~1.3.2"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1008,44 +1971,45 @@
                 {
                     "name": "Mike van Riel",
                     "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2020-09-03T19:13:55+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0"
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "ext-tokenizer": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-1.x": "1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1058,42 +2022,43 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2020-09-17T18:55:26+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.2",
+            "version": "1.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
+                "reference": "245710e971a030f42e08f4912863805570f23d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
-                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
+                "reference": "245710e971a030f42e08f4912863805570f23d39",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0|^2.0"
+                "doctrine/instantiator": "^1.2",
+                "php": "^7.2 || ~8.0, <8.1",
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "sebastian/comparator": "^3.0 || ^4.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpspec/phpspec": "^6.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.11.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1121,44 +2086,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21T14:58:47+00:00"
+            "time": "2020-12-19T10:15:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.5",
+            "version": "7.0.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c19cfc7cbb0e9338d8c469c7eedecc2a428b0971"
+                "reference": "bb7c9a210c72e4709cdde67f8b7362f672f2225c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c19cfc7cbb0e9338d8c469c7eedecc2a428b0971",
-                "reference": "c19cfc7cbb0e9338d8c469c7eedecc2a428b0971",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bb7c9a210c72e4709cdde67f8b7362f672f2225c",
+                "reference": "bb7c9a210c72e4709cdde67f8b7362f672f2225c",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "^1.4.2",
-                "sebastian/code-unit-reverse-lookup": "~1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "~1.0|~2.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.1.1 || ^4.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.4.0",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1173,7 +2138,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1184,29 +2149,38 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-01-20T15:06:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-12-02T13:39:03+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1221,7 +2195,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1231,7 +2205,13 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:25:21+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1276,25 +2256,30 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1307,7 +2292,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1316,33 +2301,39 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12T18:03:57+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:20:02+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.9",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
+                "reference": "a853a0e183b9db7eed023d7933a858fa1c8d25a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/a853a0e183b9db7eed023d7933a858fa1c8d25a3",
+                "reference": "a853a0e183b9db7eed023d7933a858fa1c8d25a3",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1365,56 +2356,63 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15T14:06:22+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2020-08-04T08:28:15+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.5.7",
+            "version": "8.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3f67cee782c9abfaee5e32fd2f57cdd54bc257ba"
+                "reference": "c25f79895d27b6ecd5abfa63de1606b786a461a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3f67cee782c9abfaee5e32fd2f57cdd54bc257ba",
-                "reference": "3f67cee782c9abfaee5e32fd2f57cdd54bc257ba",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c25f79895d27b6ecd5abfa63de1606b786a461a3",
+                "reference": "c25f79895d27b6ecd5abfa63de1606b786a461a3",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^4.0.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "~1.1",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "^1.3 || ^2.0",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/object-enumerator": "~1.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0|~2.0",
-                "symfony/yaml": "~2.1|~3.0"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.0",
+                "phar-io/manifest": "^2.0.1",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.2",
+                "phpspec/prophecy": "^1.10.3",
+                "phpunit/php-code-coverage": "^7.0.12",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.3",
+                "sebastian/exporter": "^3.1.2",
+                "sebastian/global-state": "^3.0.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
+                "sebastian/version": "^2.0.1"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
-                "ext-tidy": "*",
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -1422,7 +2420,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.5.x-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
@@ -1448,79 +2446,76 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-10-03T13:04:15+00:00"
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-17T07:37:30+00:00"
         },
         {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.3",
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
-                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.4"
-            },
-            "suggest": {
-                "ext-soap": "*"
+                "php": ">=7.2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "description": "Standard interfaces for event handling.",
             "keywords": [
-                "mock",
-                "xunit"
+                "events",
+                "psr",
+                "psr-14"
             ],
-            "time": "2016-12-08T20:27:08+00:00"
+            "time": "2019-01-08T18:20:26+00:00"
         },
         {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
                 "shasum": ""
             },
             "require": {
@@ -1529,7 +2524,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -1554,27 +2549,27 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -1599,34 +2594,40 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13T06:45:14+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
-                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": ">=7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1639,6 +2640,10 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -1650,45 +2655,48 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2016-11-19T09:18:40+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:04:30+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1702,45 +2710,57 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:59:04+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1765,34 +2785,40 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:53:42+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": ">=7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1806,6 +2832,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -1814,16 +2844,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -1832,27 +2858,36 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:47:53+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "474fb9edb7ab891665d3bfc6317f42a0a150454b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/474fb9edb7ab891665d3bfc6317f42a0a150454b",
+                "reference": "474fb9edb7ab891665d3bfc6317f42a0a150454b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1860,7 +2895,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1883,33 +2918,40 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:43:24+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "1.0.0",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~1.0"
+                "php": ">=7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1929,32 +2971,38 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-01-28T13:25:10+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:40:27+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "name": "sebastian/object-reflector",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -1968,12 +3016,63 @@
             ],
             "authors": [
                 {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:37:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
                 {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
                 },
                 {
                     "name": "Adam Harvey",
@@ -1982,29 +3081,35 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11T19:50:13+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:34:24+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2024,7 +3129,65 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:30:19+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "reference": "0150cfbc4495ed2df3872fb31b26781e4e077eb4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:25:11+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2071,47 +3234,52 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.11",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "36f83f642443c46f3cf751d4d2ee5d047d757a27"
+                "reference": "d6d0cc30d8c0fda4e7b213c20509b0159a8f4556"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/36f83f642443c46f3cf751d4d2ee5d047d757a27",
-                "reference": "36f83f642443c46f3cf751d4d2ee5d047d757a27",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d6d0cc30d8c0fda4e7b213c20509b0159a8f4556",
+                "reference": "d6d0cc30d8c0fda4e7b213c20509b0159a8f4556",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/debug": "~2.8|~3.0|~4.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/string": "^5.1"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.4",
-                "symfony/process": "<3.3"
+                "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.3|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-                "symfony/lock": "~3.4|~4.0",
-                "symfony/process": "~3.3|~4.0"
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
             },
             "suggest": {
-                "psr/log-implementation": "For using the console logger",
+                "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
@@ -2134,46 +3302,60 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Console Component",
+            "description": "Eases the creation of beautiful and testable command line interfaces",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T08:49:21+00:00"
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-23T10:08:49+00:00"
         },
         {
-            "name": "symfony/debug",
-            "version": "v3.4.11",
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "b28fd73fefbac341f673f5efd707d539d6a19f68"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/b28fd73fefbac341f673f5efd707d539d6a19f68",
-                "reference": "b28fd73fefbac341f673f5efd707d539d6a19f68",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5fa56b4074d1ae755beb55617ddafe6f5d78f665",
+                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "psr/log": "~1.0"
-            },
-            "conflict": {
-                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
-            },
-            "require-dev": {
-                "symfony/http-kernel": "~2.8|~3.0|~4.0"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "2.2-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Debug\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "files": [
+                    "function.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2182,55 +3364,74 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Debug Component",
+            "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T14:03:39+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.11",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "fdd5abcebd1061ec647089c6c41a07ed60af09f8"
+                "reference": "d08d6ec121a425897951900ab692b612a61d6240"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/fdd5abcebd1061ec647089c6c41a07ed60af09f8",
-                "reference": "fdd5abcebd1061ec647089c6c41a07ed60af09f8",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d08d6ec121a425897951900ab692b612a61d6240",
+                "reference": "d08d6ec121a425897951900ab692b612a61d6240",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/event-dispatcher-contracts": "^2",
+                "symfony/polyfill-php80": "^1.15"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.3"
+                "symfony/dependency-injection": "<4.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0"
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/stopwatch": "^4.4|^5.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
                 "symfony/http-kernel": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\EventDispatcher\\": ""
@@ -2253,34 +3454,119 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony EventDispatcher Component",
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
-            "time": "2018-04-06T07:35:25+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-18T17:12:37+00:00"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "v3.4.11",
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "8e03ca3fa52a0f56b87506f38cf7bd3f9442b3a0"
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/8e03ca3fa52a0f56b87506f38cf7bd3f9442b3a0",
-                "reference": "8e03ca3fa52a0f56b87506f38cf7bd3f9442b3a0",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0ba7d54483095a198fa51781bc608d17e84dffa2",
+                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-ctype": "~1.8"
+                "php": ">=7.2.5",
+                "psr/event-dispatcher": "^1"
+            },
+            "suggest": {
+                "symfony/event-dispatcher-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "2.2-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v5.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/710d364200997a5afde34d9fe57bd52f3cc1e108",
+                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
@@ -2303,33 +3589,42 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Filesystem Component",
+            "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T08:49:21+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-12T10:38:38+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.11",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "472a92f3df8b247b49ae364275fb32943b9656c6"
+                "reference": "0d639a0943822626290d169965804f79400e6a04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/472a92f3df8b247b49ae364275fb32943b9656c6",
-                "reference": "472a92f3df8b247b49ae364275fb32943b9656c6",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0d639a0943822626290d169965804f79400e6a04",
+                "reference": "0d639a0943822626290d169965804f79400e6a04",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=7.2.5"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
@@ -2352,33 +3647,45 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Finder Component",
+            "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T08:49:21+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-15T18:55:04+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v3.4.16",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "1cf7d8e704a9cc4164c92e430f2dfa3e6983661d"
+                "reference": "5d0f633f9bbfcf7ec642a2b5037268e61b0a62ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/1cf7d8e704a9cc4164c92e430f2dfa3e6983661d",
-                "reference": "1cf7d8e704a9cc4164c92e430f2dfa3e6983661d",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/5d0f633f9bbfcf7ec642a2b5037268e61b0a62ce",
+                "reference": "5d0f633f9bbfcf7ec642a2b5037268e61b0a62ce",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-php73": "~1.0",
+                "symfony/polyfill-php80": "^1.15"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\OptionsResolver\\": ""
@@ -2401,36 +3708,57 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony OptionsResolver Component",
+            "description": "Provides an improved replacement for the array_replace PHP function",
             "homepage": "https://symfony.com",
             "keywords": [
                 "config",
                 "configuration",
                 "options"
             ],
-            "time": "2018-09-17T17:29:18+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-27T12:56:27+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.8.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2447,12 +3775,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -2463,37 +3791,55 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-04-30T19:57:29+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.8.0",
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "3296adf6a6454a050679cde90f95350ad604b171"
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/3296adf6a6454a050679cde90f95350ad604b171",
-                "reference": "3296adf6a6454a050679cde90f95350ad604b171",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/5601e09b69f26c1828b13b6bb87cb07cddba3170",
+                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
-                "ext-mbstring": "For best performance"
+                "ext-intl": "For best performance"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
                 },
                 "files": [
                     "bootstrap.php"
@@ -2513,43 +3859,65 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony polyfill for the Mbstring extension",
+            "description": "Symfony polyfill for intl's grapheme_* functions",
             "homepage": "https://symfony.com",
             "keywords": [
                 "compatibility",
-                "mbstring",
+                "grapheme",
+                "intl",
                 "polyfill",
                 "portable",
                 "shim"
             ],
-            "time": "2018-04-26T10:06:28+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
-            "name": "symfony/polyfill-php54",
-            "version": "v1.8.0",
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-php54.git",
-                "reference": "6c3a2b84c6025e4ea3f6a19feac35408c64b22e1"
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php54/zipball/6c3a2b84c6025e4ea3f6a19feac35408c64b22e1",
-                "reference": "6c3a2b84c6025e4ea3f6a19feac35408c64b22e1",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Polyfill\\Php54\\": ""
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
                 },
                 "files": [
                     "bootstrap.php"
@@ -2572,50 +3940,58 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony polyfill backporting some PHP 5.4+ features to lower PHP versions",
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
             "homepage": "https://symfony.com",
             "keywords": [
                 "compatibility",
+                "intl",
+                "normalizer",
                 "polyfill",
                 "portable",
                 "shim"
             ],
-            "time": "2018-04-26T10:06:28+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.9.0",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "1e24b0c4a56d55aaf368763a06c6d1c7d3194934"
+                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/1e24b0c4a56d55aaf368763a06c6d1c7d3194934",
-                "reference": "1e24b0c4a56d55aaf368763a06c6d1c7d3194934",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/5f03a781d984aae42cebd18e7912fa80f02ee644",
+                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644",
                 "shasum": ""
             },
             "require": {
-                "paragonie/random_compat": "~1.0|~2.0|~9.99",
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
-            "type": "library",
+            "type": "metapackage",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php70\\": ""
+                    "dev-main": "1.20-dev"
                 },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2639,29 +4015,47 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.9.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "95c50420b0baed23852452a7f0c7b527303ed5ae"
+                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/95c50420b0baed23852452a7f0c7b527303ed5ae",
-                "reference": "95c50420b0baed23852452a7f0c7b527303ed5ae",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
+                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2694,31 +4088,117 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v3.4.11",
+            "name": "symfony/polyfill-php73",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "4cbf2db9abcb01486a21b7a059e03a62fae63187"
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4cbf2db9abcb01486a21b7a059e03a62fae63187",
-                "reference": "4cbf2db9abcb01486a21b7a059e03a62fae63187",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "313a38f09c77fbcdc1d223e57d368cea76a2fd2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/313a38f09c77fbcdc1d223e57d368cea76a2fd2f",
+                "reference": "313a38f09c77fbcdc1d223e57d368cea76a2fd2f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "type": "library",
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Process\\": ""
@@ -2741,33 +4221,119 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Process Component",
+            "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T08:49:21+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-27T10:15:41+00:00"
         },
         {
-            "name": "symfony/stopwatch",
-            "version": "v3.4.11",
+            "name": "symfony/service-contracts",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "eb17cfa072cab26537ac37e9c4ece6c0361369af"
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/eb17cfa072cab26537ac37e9c4ece6c0361369af",
-                "reference": "eb17cfa072cab26537ac37e9c4ece6c0361369af",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=7.2.5",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "2.2-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v5.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "b12274acfab9d9850c52583d136a24398cdf1a0c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/b12274acfab9d9850c52583d136a24398cdf1a0c",
+                "reference": "b12274acfab9d9850c52583d136a24398cdf1a0c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/service-contracts": "^1.0|^2"
+            },
+            "type": "library",
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Stopwatch\\": ""
@@ -2790,43 +4356,60 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Stopwatch Component",
+            "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
-            "time": "2018-02-17T14:55:25+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-27T10:15:41+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.2.2",
+            "name": "symfony/string",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "50eadbd7926e31842893c957eca362b21592a97d"
+                "url": "https://github.com/symfony/string.git",
+                "reference": "4e78d7d47061fa183639927ec40d607973699609"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/50eadbd7926e31842893c957eca362b21592a97d",
-                "reference": "50eadbd7926e31842893c957eca362b21592a97d",
+                "url": "https://api.github.com/repos/symfony/string/zipball/4e78d7d47061fa183639927ec40d607973699609",
+                "reference": "4e78d7d47061fa183639927ec40d607973699609",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
             },
             "require-dev": {
-                "symfony/console": "~2.8|~3.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
+                    "Symfony\\Component\\String\\": ""
                 },
+                "files": [
+                    "Resources/functions.php"
+                ],
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -2837,45 +4420,112 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Yaml Component",
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
             "homepage": "https://symfony.com",
-            "time": "2017-01-03T13:51:32+00:00"
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-16T10:20:28+00:00"
         },
         {
-            "name": "webmozart/assert",
+            "name": "theseer/tokenizer",
             "version": "1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
             },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -2897,7 +4547,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2020-07-08T17:02:28+00:00"
         }
     ],
     "aliases": [],
@@ -2906,5 +4556,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,7 @@
-<phpunit colors="true" strict="true">
+<phpunit colors="true">
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
         </whitelist>
-        <blacklist>
-            <directory suffix=".php">./vendor</directory>
-        </blacklist>
     </filter>
 </phpunit>

--- a/src/Models/Cart/Cart.php
+++ b/src/Models/Cart/Cart.php
@@ -79,9 +79,6 @@ class Cart implements Serializeable, \JsonSerializable
         return $this->attributes;
     }
 
-    /**
-     * @param array $attributes
-     */
     public function setAttributes(array $attributes)
     {
         $this->attributes = $attributes;

--- a/src/Models/CustomCollection.php
+++ b/src/Models/CustomCollection.php
@@ -96,7 +96,7 @@ class CustomCollection implements Serializeable, \JsonSerializable
     }
 
     /**
-     * @return null|string
+     * @return string|null
      */
     public function getTemplateSuffix()
     {
@@ -104,7 +104,7 @@ class CustomCollection implements Serializeable, \JsonSerializable
     }
 
     /**
-     * @return null|string
+     * @return string|null
      */
     public function getPublishedScope()
     {

--- a/src/Models/Customer.php
+++ b/src/Models/Customer.php
@@ -51,10 +51,10 @@ class Customer implements Serializeable, \JsonSerializable
     /** @var string */
     protected $lastOrderName;
 
-    /** @var $array */
+    /** @var array */
     protected $defaultAddress;
 
-    /** @var $array */
+    /** @var array */
     protected $addresses;
 
     /** @var string */

--- a/src/Models/OrderLineItem.php
+++ b/src/Models/OrderLineItem.php
@@ -204,9 +204,6 @@ class OrderLineItem implements Serializeable, \JsonSerializable
         $this->variantInventoryManagement = $variantInventoryManagement;
     }
 
-    /**
-     * @param array $properties
-     */
     public function setProperties(array $properties)
     {
         $this->properties = $properties;
@@ -228,9 +225,6 @@ class OrderLineItem implements Serializeable, \JsonSerializable
         $this->fulfillmentStatus = $fulfillmentStatus;
     }
 
-    /**
-     * @param Collection $taxLines
-     */
     public function setTaxLines(Collection $taxLines)
     {
         $this->taxLines = $taxLines;

--- a/src/Models/RefundLineItem.php
+++ b/src/Models/RefundLineItem.php
@@ -2,8 +2,8 @@
 
 namespace BoldApps\ShopifyToolkit\Models;
 
-use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 use BoldApps\ShopifyToolkit\Contracts\Serializeable;
+use BoldApps\ShopifyToolkit\Traits\HasAttributesTrait;
 
 class RefundLineItem implements Serializeable, \JsonSerializable
 {

--- a/src/Services/ApplicationCharge.php
+++ b/src/Services/ApplicationCharge.php
@@ -7,8 +7,6 @@ use BoldApps\ShopifyToolkit\Models\ApplicationCharge as ShopifyApplicationCharge
 class ApplicationCharge extends Base
 {
     /**
-     * @param ShopifyApplicationCharge $applicationCharge
-     *
      * @return ShopifyApplicationCharge \ object
      */
     public function create(ShopifyApplicationCharge $applicationCharge)
@@ -33,8 +31,6 @@ class ApplicationCharge extends Base
     }
 
     /**
-     * @param ShopifyApplicationCharge $applicationCharge
-     *
      * @return ShopifyApplicationCharge \ object
      */
     public function activate(ShopifyApplicationCharge $applicationCharge)
@@ -48,8 +44,6 @@ class ApplicationCharge extends Base
     }
 
     /**
-     * @param ShopifyApplicationCharge $applicationCharge
-     *
      * @return array
      */
     public function delete(ShopifyApplicationCharge $applicationCharge)

--- a/src/Services/Asset.php
+++ b/src/Services/Asset.php
@@ -4,9 +4,9 @@ namespace BoldApps\ShopifyToolkit\Services;
 
 use BoldApps\ShopifyToolkit\Exceptions\NotFoundException;
 use BoldApps\ShopifyToolkit\Models\Asset as AssetModel;
+use BoldApps\ShopifyToolkit\Models\Theme as ShopifyTheme;
 use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
 use BoldApps\ShopifyToolkit\Services\Theme as ShopifyThemeService;
-use BoldApps\ShopifyToolkit\Models\Theme as ShopifyTheme;
 use Illuminate\Support\Collection;
 
 class Asset extends Base
@@ -50,7 +50,7 @@ class Asset extends Base
     /**
      * @param string $key
      *
-     * @return null|object
+     * @return object|null
      *
      * @throws \Exception
      */
@@ -113,8 +113,6 @@ class Asset extends Base
     }
 
     /**
-     * @param AssetModel $asset
-     *
      * @return object
      */
     public function create(AssetModel $asset)
@@ -133,8 +131,6 @@ class Asset extends Base
     }
 
     /**
-     * @param AssetModel $asset
-     *
      * @return object
      */
     public function update(AssetModel $asset)

--- a/src/Services/Base.php
+++ b/src/Services/Base.php
@@ -46,8 +46,6 @@ abstract class Base
     }
 
     /**
-     * @param Serializeable|null $entity
-     *
      * @return array
      */
     public function serializeModel(Serializeable $entity = null)
@@ -163,9 +161,6 @@ abstract class Base
         return $this->shopifyApiVersion;
     }
 
-    /**
-     * @param string $shopifyApiVersion
-     */
     public function setShopifyApiVersion(string $shopifyApiVersion)
     {
         $this->shopifyApiVersion = $shopifyApiVersion;

--- a/src/Services/Cart.php
+++ b/src/Services/Cart.php
@@ -3,8 +3,8 @@
 namespace BoldApps\ShopifyToolkit\Services;
 
 use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
-use BoldApps\ShopifyToolkit\Models\Cart\Item as CartItemModel;
 use BoldApps\ShopifyToolkit\Models\Cart\Cart as CartModel;
+use BoldApps\ShopifyToolkit\Models\Cart\Item as CartItemModel;
 use BoldApps\ShopifyToolkit\Models\Option as OptionModel;
 use GuzzleHttp\Cookie\SetCookie;
 use Illuminate\Support\Collection;
@@ -82,7 +82,6 @@ class Cart extends Base
     }
 
     /**
-     * @param CartModel     $cart
      * @param string        $cartToken
      * @param string | null $password
      *

--- a/src/Services/Collect.php
+++ b/src/Services/Collect.php
@@ -2,16 +2,16 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Collect as ShopifyCollect;
 use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class Collect extends CollectionEntity
 {
     /**
      * Collect constructor.
-     *
-     * @param ShopifyClient $client
      */
     public function __construct(ShopifyClient $client)
     {
@@ -19,9 +19,10 @@ class Collect extends CollectionEntity
     }
 
     /**
-     * @param ShopifyCollect $collect
-     *
      * @return ShopifyCollect | object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function create(ShopifyCollect $collect)
     {
@@ -36,6 +37,9 @@ class Collect extends CollectionEntity
      * @param int $id
      *
      * @return ShopifyCollect | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getById($id)
     {
@@ -48,6 +52,9 @@ class Collect extends CollectionEntity
      * @param array $params
      *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getByParams($params = [])
     {
@@ -64,6 +71,9 @@ class Collect extends CollectionEntity
      * @param array $params
      *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function count($params = [])
     {
@@ -73,9 +83,10 @@ class Collect extends CollectionEntity
     }
 
     /**
-     * @param ShopifyCollect $collect
-     *
      * @return ShopifyCollect | array
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function delete(ShopifyCollect $collect)
     {

--- a/src/Services/CollectionEntity.php
+++ b/src/Services/CollectionEntity.php
@@ -5,11 +5,9 @@ namespace BoldApps\ShopifyToolkit\Services;
 abstract class CollectionEntity extends Base
 {
     /**
-     * @param $params
-     *
      * @return \Illuminate\Support\Collection
      */
-    abstract public function getByParams($params);
+    abstract public function getByParams(array $params);
 
     /**
      * @return PageInfo
@@ -20,12 +18,9 @@ abstract class CollectionEntity extends Base
     }
 
     /**
-     * @param string $pageInfo
-     * @param int    $limit
-     *
      * @return \Illuminate\Support\Collection
      */
-    public function getByPageInfo($pageInfo, $limit = 5)
+    public function getByPageInfo(string $pageInfo, int $limit = 5)
     {
         return $this->getByParams([
             'page_info' => $pageInfo,

--- a/src/Services/Country.php
+++ b/src/Services/Country.php
@@ -2,15 +2,18 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Country as ShopifyCountry;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class Country extends Base
 {
     /**
-     * @param ShopifyCountry $country
-     *
      * @return ShopifyCountry | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function create(ShopifyCountry $country)
     {
@@ -35,6 +38,9 @@ class Country extends Base
      * @param array $filter
      *
      * @return int
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function count($filter = [])
     {
@@ -44,12 +50,15 @@ class Country extends Base
     }
 
     /**
-     * @deprecated Use getByParams()
-     * @see getByParams()
-     *
      * @param array $filter
      *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
+     *
+     * @deprecated Use getByParams()
+     * @see getByParams()
      */
     public function getAll($filter = [])
     {
@@ -66,6 +75,9 @@ class Country extends Base
      * @param array $params
      *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getByParams($params = [])
     {
@@ -83,6 +95,9 @@ class Country extends Base
      * @param array $filter
      *
      * @return ShopifyCountry | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getById($countryId, $filter = [])
     {
@@ -92,9 +107,10 @@ class Country extends Base
     }
 
     /**
-     * @param ShopifyCountry $country
-     *
      * @return object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function update(ShopifyCountry $country)
     {
@@ -105,9 +121,10 @@ class Country extends Base
     }
 
     /**
-     * @param ShopifyCountry $country
-     *
      * @return array
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function delete(ShopifyCountry $country)
     {

--- a/src/Services/CustomCollection.php
+++ b/src/Services/CustomCollection.php
@@ -2,18 +2,20 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\CustomCollection as ShopifyCustomCollection;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class CustomCollection extends CollectionEntity
 {
     /**
-     * @param ShopifyCustomCollection $collection
-     * @param bool                    $publish
-     *
      * @return object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function create(ShopifyCustomCollection $collection, $publish = true)
+    public function create(ShopifyCustomCollection $collection, bool $publish = true)
     {
         $serializedModel = ['custom_collection' => array_merge($this->serializeModel($collection), ['published' => $publish])];
 
@@ -26,6 +28,9 @@ class CustomCollection extends CollectionEntity
      * @param $id
      *
      * @return ShopifyCustomCollection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getById($id)
     {
@@ -35,16 +40,15 @@ class CustomCollection extends CollectionEntity
     }
 
     /**
+     * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
+     *
      * @deprecated Use getByParams()
      * @see getByParams()
-     *
-     * @param int   $page
-     * @param int   $limit
-     * @param array $filter
-     *
-     * @return Collection
      */
-    public function getAll($page = 1, $limit = 50, $filter = [])
+    public function getAll(int $page = 1, int $limit = 50, array $filter = [])
     {
         $raw = $this->client->get('admin/custom_collections.json', array_merge(['page' => $page, 'limit' => $limit], $filter));
 
@@ -58,7 +62,10 @@ class CustomCollection extends CollectionEntity
     /**
      * @param $params
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getByParams($params)
     {
@@ -72,9 +79,10 @@ class CustomCollection extends CollectionEntity
     }
 
     /**
-     * @param ShopifyCustomCollection $collection
-     *
      * @return object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function update(ShopifyCustomCollection $collection)
     {
@@ -86,9 +94,10 @@ class CustomCollection extends CollectionEntity
     }
 
     /**
-     * @param ShopifyCustomCollection $collection
+     * @return array
      *
-     * @return object
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function delete(ShopifyCustomCollection $collection)
     {
@@ -96,11 +105,12 @@ class CustomCollection extends CollectionEntity
     }
 
     /**
-     * @param array $filter
-     *
      * @return int
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function count($filter = [])
+    public function count(array $filter = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/custom_collections/count.json", $filter);
 
@@ -108,11 +118,12 @@ class CustomCollection extends CollectionEntity
     }
 
     /**
-     * @param $filter
-     *
      * @return int
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function countByParams($filter = [])
+    public function countByParams(array $filter = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/custom_collections/count.json", $filter);
 

--- a/src/Services/Customer.php
+++ b/src/Services/Customer.php
@@ -2,7 +2,9 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Customer as ShopifyCustomer;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class Customer extends CollectionEntity
@@ -11,6 +13,9 @@ class Customer extends CollectionEntity
      * @param $id
      *
      * @return ShopifyCustomer|object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function getById($id)
     {
@@ -20,16 +25,15 @@ class Customer extends CollectionEntity
     }
 
     /**
+     * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
+     *
      * @deprecated Use getByParams()
      * @see getByParams()
-     *
-     * @param int   $page
-     * @param int   $limit
-     * @param array $filter
-     *
-     * @return Collection
      */
-    public function getAll($page = 1, $limit = 50, $filter = [])
+    public function getAll(int $page = 1, int $limit = 50, array $filter = [])
     {
         $raw = $this->client->get('admin/customers.json', array_merge(['page' => $page, 'limit' => $limit], $filter));
 
@@ -41,11 +45,12 @@ class Customer extends CollectionEntity
     }
 
     /**
-     * @param array $params
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getByParams($params)
+    public function getByParams(array $params)
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/customers.json", $params);
 
@@ -57,13 +62,14 @@ class Customer extends CollectionEntity
     }
 
     /**
-     * @param array $parms
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function searchByParams($parms)
+    public function searchByParams(array $params)
     {
-        $raw = $this->client->get("{$this->getApiBasePath()}/customers/search.json", $parms);
+        $raw = $this->client->get("{$this->getApiBasePath()}/customers/search.json", $params);
 
         $customers = array_map(function ($customer) {
             return $this->unserializeModel($customer, ShopifyCustomer::class);
@@ -73,11 +79,12 @@ class Customer extends CollectionEntity
     }
 
     /**
-     * @param array $filter
-     *
      * @return int
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function count($filter = [])
+    public function count(array $filter = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/customers/count.json", $filter);
 
@@ -85,11 +92,12 @@ class Customer extends CollectionEntity
     }
 
     /**
-     * @param $filter
-     *
      * @return int
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function countByParams($filter = [])
+    public function countByParams(array $filter = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/customers/count.json", $filter);
 
@@ -107,9 +115,10 @@ class Customer extends CollectionEntity
     }
 
     /**
-     * @param ShopifyCustomer $customer
-     *
      * @return ShopifyCustomer | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function create(ShopifyCustomer $customer)
     {
@@ -121,9 +130,10 @@ class Customer extends CollectionEntity
     }
 
     /**
-     * @param ShopifyCustomer $customer
-     *
      * @return ShopifyCustomer | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function update(ShopifyCustomer $customer)
     {
@@ -135,9 +145,10 @@ class Customer extends CollectionEntity
     }
 
     /**
-     * @param ShopifyCustomer $customer
+     * @return array
      *
-     * @return ShopifyCustomer | object
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function delete(ShopifyCustomer $customer)
     {
@@ -145,13 +156,12 @@ class Customer extends CollectionEntity
     }
 
     /**
-     * @param int   $shopifyCustomerId
-     * @param array $params
-     * @param array $body
-     *
      * @return array
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function sendAccountCreationInvite($shopifyCustomerId, $params = [], $body = [])
+    public function sendAccountCreationInvite(int $shopifyCustomerId, array $params = [], array $body = [])
     {
         return $this->client->post("{$this->getApiBasePath()}/customers/{$shopifyCustomerId}/send_invite.json", $params, $body);
     }

--- a/src/Services/CustomerAddress.php
+++ b/src/Services/CustomerAddress.php
@@ -2,19 +2,21 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Customer as ShopifyCustomer;
 use BoldApps\ShopifyToolkit\Models\CustomerAddress as ShopifyCustomerAddress;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class CustomerAddress extends Base
 {
     /**
-     * @param ShopifyCustomer $customer
-     * @param int             $id
-     *
      * @return ShopifyCustomerAddress|object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
-    public function getById($customer, $id)
+    public function getById(ShopifyCustomer $customer, int $id)
     {
         $customerId = $customer->getId();
         $raw = $this->client->get("{$this->getApiBasePath()}/customers/$customerId/addresses/$id.json");
@@ -23,17 +25,15 @@ class CustomerAddress extends Base
     }
 
     /**
-     * @deprecated Use getByParams()
-     * @see getByParams()
-     *
-     * @param ShopifyCustomer $customer
-     * @param int             $page
-     * @param int             $limit
-     * @param array           $filter
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
+     *
+     * @see getByParams()
+     * @deprecated Use getByParams()
      */
-    public function getAll($customer, $page = 1, $limit = 50, $filter = [])
+    public function getAll(ShopifyCustomer $customer, int $page = 1, int $limit = 50, array $filter = [])
     {
         $customerId = $customer->getId();
         $raw = $this->client->get("admin/customers/$customerId/addresses.json", array_merge(['page' => $page, 'limit' => $limit], $filter));
@@ -46,12 +46,12 @@ class CustomerAddress extends Base
     }
 
     /**
-     * @param ShopifyCustomer $customer
-     * @param array           $params
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getByParams($customer, $params = [])
+    public function getByParams(ShopifyCustomer $customer, array $params = [])
     {
         $customerId = $customer->getId();
         $raw = $this->client->get("{$this->getApiBasePath()}/customers/$customerId/addresses.json", $params);
@@ -64,12 +64,12 @@ class CustomerAddress extends Base
     }
 
     /**
-     * @param ShopifyCustomer        $customer
-     * @param ShopifyCustomerAddress $address
-     *
      * @return ShopifyCustomerAddress | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function create($customer, ShopifyCustomerAddress $address)
+    public function create(ShopifyCustomer $customer, ShopifyCustomerAddress $address)
     {
         $customerId = $customer->getId();
         $serializedModel = ['address' => array_merge($this->serializeModel($address))];

--- a/src/Services/CustomerSavedSearch.php
+++ b/src/Services/CustomerSavedSearch.php
@@ -2,9 +2,11 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Customer as CustomerModel;
 use BoldApps\ShopifyToolkit\Models\CustomerSavedSearch as CustomerSavedSearchModel;
 use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class CustomerSavedSearch extends CollectionEntity
@@ -30,9 +32,10 @@ class CustomerSavedSearch extends CollectionEntity
     }
 
     /**
-     * @param CustomerSavedSearchModel $customerSavedSearch
-     *
      * @return CustomerSavedSearchModel | object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function create(CustomerSavedSearchModel $customerSavedSearch)
     {
@@ -44,9 +47,10 @@ class CustomerSavedSearch extends CollectionEntity
     }
 
     /**
-     * @param CustomerSavedSearchModel $customerSavedSearch
-     *
      * @return CustomerSavedSearchModel | object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function edit(CustomerSavedSearchModel $customerSavedSearch)
     {
@@ -58,21 +62,21 @@ class CustomerSavedSearch extends CollectionEntity
     }
 
     /**
-     * @param CustomerSavedSearchModel $customerSavedSearch
-     *
-     * @return array
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function delete(CustomerSavedSearchModel $customerSavedSearch)
+    public function delete(CustomerSavedSearchModel $customerSavedSearch): array
     {
         return $this->client->delete("{$this->getApiBasePath()}/customer_saved_searches/{$customerSavedSearch->getId()}.json");
     }
 
     /**
-     * @param $params
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getByParams($params)
+    public function getByParams(array $params)
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/customer_saved_searches.json", $params);
 
@@ -84,12 +88,12 @@ class CustomerSavedSearch extends CollectionEntity
     }
 
     /**
-     * @param int   $customerSavedSearchId
-     * @param array $params
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getAllCustomersById($customerSavedSearchId, $params = [])
+    public function getAllCustomersById(int $customerSavedSearchId, array $params = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/customer_saved_searches/$customerSavedSearchId/customers.json", $params);
 

--- a/src/Services/DiscountCode.php
+++ b/src/Services/DiscountCode.php
@@ -2,15 +2,24 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\BadRequestException;
+use BoldApps\ShopifyToolkit\Exceptions\NotAcceptableException;
+use BoldApps\ShopifyToolkit\Exceptions\NotFoundException;
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
+use BoldApps\ShopifyToolkit\Exceptions\TooManyRequestsException;
+use BoldApps\ShopifyToolkit\Exceptions\UnauthorizedException;
+use BoldApps\ShopifyToolkit\Exceptions\UnprocessableEntityException;
 use BoldApps\ShopifyToolkit\Models\DiscountCode as ShopifyDiscountCode;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class DiscountCode extends Base
 {
     /**
-     * @param ShopifyDiscountCode $discountCode
-     *
      * @return ShopifyDiscountCode | object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function create(ShopifyDiscountCode $discountCode)
     {
@@ -26,18 +35,18 @@ class DiscountCode extends Base
      *
      * @return object
      */
-    public function createFromArray($array)
+    public function createFromArray(array $array)
     {
         return $this->unserializeModel($array, ShopifyDiscountCode::class);
     }
 
     /**
-     * @param int   $priceRuleId
-     * @param array $filter
-     *
      * @return Collection
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
-    public function getAllByPriceRuleId($priceRuleId, $filter = [])
+    public function getAllByPriceRuleId(int $priceRuleId, array $filter = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/price_rules/$priceRuleId/discount_codes.json", $filter);
 
@@ -49,12 +58,12 @@ class DiscountCode extends Base
     }
 
     /**
-     * @param int $priceRuleId
-     * @param int $discountCodeId
-     *
      * @return ShopifyDiscountCode | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getByDiscountCodeId($priceRuleId, $discountCodeId)
+    public function getByDiscountCodeId(int $priceRuleId, int $discountCodeId)
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/price_rules/$priceRuleId/discount_codes/$discountCodeId.json");
 
@@ -62,11 +71,18 @@ class DiscountCode extends Base
     }
 
     /**
-     * @param string $discountCode
-     *
      * @return ShopifyDiscountCode | object | null
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
+     * @throws BadRequestException
+     * @throws NotAcceptableException
+     * @throws NotFoundException
+     * @throws TooManyRequestsException
+     * @throws UnauthorizedException
+     * @throws UnprocessableEntityException
      */
-    public function lookup($discountCode)
+    public function lookup(string $discountCode)
     {
         $result = null;
         $redirectLocation = $this->client->getRedirectLocation("{$this->getApiBasePath()}/discount_codes/lookup.json", ['code' => $discountCode]);
@@ -80,9 +96,10 @@ class DiscountCode extends Base
     }
 
     /**
-     * @param ShopifyDiscountCode $discountCode
-     *
      * @return object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function update(ShopifyDiscountCode $discountCode)
     {
@@ -94,11 +111,10 @@ class DiscountCode extends Base
     }
 
     /**
-     * @param ShopifyDiscountCode $discountCode
-     *
-     * @return array
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function delete(ShopifyDiscountCode $discountCode)
+    public function delete(ShopifyDiscountCode $discountCode): array
     {
         $priceRuleId = $discountCode->getPriceRuleId();
 

--- a/src/Services/DraftOrder.php
+++ b/src/Services/DraftOrder.php
@@ -2,17 +2,19 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
-use BoldApps\ShopifyToolkit\Models\DraftOrder as ShopifyDraftOrder;
-use BoldApps\ShopifyToolkit\Models\TaxLine as TaxLineModel;
-use BoldApps\ShopifyToolkit\Services\TaxLine as TaxLineService;
-use Illuminate\Support\Collection;
-use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
-use BoldApps\ShopifyToolkit\Services\DraftOrderLineItem as DraftOrderLineItemService;
-use BoldApps\ShopifyToolkit\Models\DraftOrderLineItem as DraftOrderLineItemModel;
-use BoldApps\ShopifyToolkit\Services\DraftOrderAppliedDiscount as AppliedDiscountService;
-use BoldApps\ShopifyToolkit\Models\DraftOrderAppliedDiscount as AppliedDiscountModel;
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Cart\Cart as CartModel;
+use BoldApps\ShopifyToolkit\Models\DraftOrder as ShopifyDraftOrder;
+use BoldApps\ShopifyToolkit\Models\DraftOrderAppliedDiscount as AppliedDiscountModel;
+use BoldApps\ShopifyToolkit\Models\DraftOrderLineItem as DraftOrderLineItemModel;
+use BoldApps\ShopifyToolkit\Models\TaxLine as TaxLineModel;
+use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
+use BoldApps\ShopifyToolkit\Services\DraftOrderAppliedDiscount as AppliedDiscountService;
+use BoldApps\ShopifyToolkit\Services\DraftOrderLineItem as DraftOrderLineItemService;
+use BoldApps\ShopifyToolkit\Services\TaxLine as TaxLineService;
 use BoldApps\ShopifyToolkit\Traits\TranslatePropertiesTrait;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Collection;
 
 class DraftOrder extends Base
 {
@@ -44,10 +46,8 @@ class DraftOrder extends Base
     /**
      * DraftOrder constructor.
      *
-     * @param Client                                    $client
-     * @param \BoldApps\ShopifyToolkit\Services\TaxLine $taxLineService
-     * @param DraftOrderLineItemService                 $draftOrderLineItemService
-     * @param DraftOrderAppliedDiscount                 $appliedDiscountService
+     * @param Client                    $client
+     * @param DraftOrderAppliedDiscount $appliedDiscountService
      */
     public function __construct(
         ShopifyClient $client,
@@ -65,6 +65,9 @@ class DraftOrder extends Base
      * @param $shopifyDraftOrder
      *
      * @return object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function create($shopifyDraftOrder)
     {
@@ -78,6 +81,9 @@ class DraftOrder extends Base
      * @param $id
      *
      * @return ShopifyDraftOrder
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getById($id)
     {
@@ -126,7 +132,10 @@ class DraftOrder extends Base
     /**
      * @param $id
      *
-     * @return object
+     * @return array
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function delete($id)
     {

--- a/src/Services/DraftOrderLineItem.php
+++ b/src/Services/DraftOrderLineItem.php
@@ -2,15 +2,15 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Models\Cart\Item as CartItem;
+use BoldApps\ShopifyToolkit\Models\DraftOrderAppliedDiscount as AppliedDiscountModel;
 use BoldApps\ShopifyToolkit\Models\DraftOrderLineItem as DraftOrderLineItemModel;
+use BoldApps\ShopifyToolkit\Models\TaxLine as TaxLineModel;
 use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
 use BoldApps\ShopifyToolkit\Services\DraftOrderAppliedDiscount as AppliedDiscountService;
-use BoldApps\ShopifyToolkit\Models\DraftOrderAppliedDiscount as AppliedDiscountModel;
 use BoldApps\ShopifyToolkit\Services\TaxLine as TaxLineService;
-use BoldApps\ShopifyToolkit\Models\TaxLine as TaxLineModel;
-use BoldApps\ShopifyToolkit\Models\Cart\Item as CartItem;
-use Illuminate\Support\Collection;
 use BoldApps\ShopifyToolkit\Traits\TranslatePropertiesTrait;
+use Illuminate\Support\Collection;
 
 class DraftOrderLineItem extends Base
 {
@@ -39,7 +39,6 @@ class DraftOrderLineItem extends Base
      *
      * @param Client                    $client
      * @param DraftOrderAppliedDiscount $appliedDiscountService
-     * @param TaxLineService            $taxlineService
      */
     public function __construct(ShopifyClient $client,
                                 AppliedDiscountService $appliedDiscountService,
@@ -61,9 +60,9 @@ class DraftOrderLineItem extends Base
     }
 
     /**
-     * @param CartItem $cartItem
-     *
      * @return DraftOrderLineItemModel
+     *
+     * @throws \ReflectionException
      */
     public function createDraftOrderLineItemFromCartItem(CartItem $cartItem)
     {

--- a/src/Services/Fulfillment.php
+++ b/src/Services/Fulfillment.php
@@ -2,14 +2,18 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Fulfillment as ShopifyFulfillment;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Collection;
 
 class Fulfillment extends Base
 {
     /**
-     * @param ShopifyFulfillment $fulfillment
-     *
      * @return ShopifyFulfillment | object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function create(ShopifyFulfillment $fulfillment)
     {
@@ -21,11 +25,12 @@ class Fulfillment extends Base
     }
 
     /**
-     * @param int $orderId
+     * @return ShopifyFulfillment | Collection
      *
-     * @return ShopifyFulfillment | \Illuminate\Support\Collection
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
-    public function get($orderId)
+    public function get(int $orderId)
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/orders/{$orderId}/fulfillments.json", []);
         $results = collect();

--- a/src/Services/Image.php
+++ b/src/Services/Image.php
@@ -2,17 +2,19 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
-use BoldApps\ShopifyToolkit\Models\Product as ShopifyProduct;
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Image as ShopifyImage;
+use BoldApps\ShopifyToolkit\Models\Product as ShopifyProduct;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class Image extends Base
 {
     /**
-     * @param ShopifyProduct $product
-     * @param ShopifyImage   $image
-     *
      * @return object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function createImageForProduct(ShopifyProduct $product, ShopifyImage $image)
     {
@@ -34,12 +36,12 @@ class Image extends Base
     }
 
     /**
-     * @param ShopifyProduct $product
-     * @param array          $params
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getAllProductImages(ShopifyProduct $product, $params = [])
+    public function getAllProductImages(ShopifyProduct $product, array $params = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/products/{$product->getId()}/images.json", $params);
 
@@ -51,10 +53,12 @@ class Image extends Base
     }
 
     /**
-     * @param ShopifyProduct $product
-     * @param                $id
+     * @param $id
      *
      * @return ShopifyImage|object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getProductImageById(ShopifyProduct $product, $id)
     {
@@ -64,10 +68,10 @@ class Image extends Base
     }
 
     /**
-     * @param ShopifyProduct $product
-     * @param ShopifyImage   $image
-     *
      * @return array
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function deleteProductImage(ShopifyProduct $product, ShopifyImage $image)
     {

--- a/src/Services/InstallAndLogin.php
+++ b/src/Services/InstallAndLogin.php
@@ -6,6 +6,7 @@ use BoldApps\ShopifyToolkit\Contracts\ApplicationInfo;
 use BoldApps\ShopifyToolkit\Contracts\ShopBaseInfo;
 use BoldApps\ShopifyToolkit\Exceptions\BadRequestException;
 use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
@@ -23,10 +24,6 @@ class InstallAndLogin
 
     /**
      * InstallAndLogin constructor.
-     *
-     * @param ApplicationInfo $applicationInfo
-     * @param ShopBaseInfo    $shopBaseInfo
-     * @param HttpClient      $client
      */
     public function __construct(
         ApplicationInfo $applicationInfo,
@@ -56,13 +53,10 @@ class InstallAndLogin
     }
 
     /**
-     * @param $code
-     *
-     * @return string
-     *
      * @throws BadRequestException
+     * @throws GuzzleException
      */
-    public function getAccessToken($code)
+    public function getAccessToken(string $code): string
     {
         $result = '';
         $path = 'admin/oauth/access_token.json';
@@ -115,7 +109,7 @@ class InstallAndLogin
             return false;
         }
 
-        $dataString = array();
+        $dataString = [];
 
         foreach ($query as $key => $value) {
             if ('hmac' == $key) {

--- a/src/Services/InventoryLevel.php
+++ b/src/Services/InventoryLevel.php
@@ -2,7 +2,9 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\InventoryLevel as ShopifyInventoryLevel;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class InventoryLevel extends CollectionEntity
@@ -18,11 +20,10 @@ class InventoryLevel extends CollectionEntity
     }
 
     /**
-     * @param array $params
-     *
-     * @return Collection
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
-    public function getByParams($params)
+    public function getByParams(array $params): Collection
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/inventory_levels.json", $params);
 
@@ -34,13 +35,12 @@ class InventoryLevel extends CollectionEntity
     }
 
     /**
-     * @param int $locationId
-     * @param int $inventoryItemId
-     * @param int $availableAdjustment
-     *
      * @return ShopifyInventoryLevel | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function adjust($locationId, $inventoryItemId, $availableAdjustment)
+    public function adjust(int $locationId, int $inventoryItemId, int $availableAdjustment)
     {
         $raw = $this->client->post("{$this->getApiBasePath()}/inventory_levels/adjust.json", [], [
             'location_id' => $locationId,
@@ -52,14 +52,12 @@ class InventoryLevel extends CollectionEntity
     }
 
     /**
-     * @param int  $locationId
-     * @param int  $inventoryItemId
-     * @param int  $available
-     * @param bool $disconnectIfNecessary
-     *
      * @return ShopifyInventoryLevel | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function set($locationId, $inventoryItemId, $available, $disconnectIfNecessary = false)
+    public function set(int $locationId, int $inventoryItemId, int $available, bool $disconnectIfNecessary = false)
     {
         $raw = $this->client->post("{$this->getApiBasePath()}/inventory_levels/set.json", [], [
             'location_id' => $locationId,
@@ -72,13 +70,14 @@ class InventoryLevel extends CollectionEntity
     }
 
     /**
-     * @param int  $locationId
-     * @param int  $inventoryItemId
      * @param bool $relocateIfNecessary
      *
      * @return ShopifyInventoryLevel | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function connect($locationId, $inventoryItemId, $relocateIfNecessary = false)
+    public function connect(int $locationId, int $inventoryItemId, $relocateIfNecessary = false)
     {
         $raw = $this->client->post("{$this->getApiBasePath()}/inventory_levels/connect.json", [], [
             'location_id' => $locationId,
@@ -90,11 +89,10 @@ class InventoryLevel extends CollectionEntity
     }
 
     /**
-     * @param ShopifyInventoryLevel $inventoryLevel
-     *
-     * @return ShopifyInventoryLevel | object
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function delete(ShopifyInventoryLevel $inventoryLevel)
+    public function delete(ShopifyInventoryLevel $inventoryLevel): array
     {
         return $this->client->delete("{$this->getApiBasePath()}/inventory_levels.json", [
             'inventory_item_id' => $inventoryLevel->getInventoryItemId(),

--- a/src/Services/Location.php
+++ b/src/Services/Location.php
@@ -2,8 +2,10 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
-use BoldApps\ShopifyToolkit\Models\Location as ShopifyLocation;
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\InventoryLevel as ShopifyInventoryLevel;
+use BoldApps\ShopifyToolkit\Models\Location as ShopifyLocation;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class Location extends Base
@@ -20,6 +22,9 @@ class Location extends Base
 
     /**
      * @return Collection
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function getAll()
     {
@@ -36,6 +41,9 @@ class Location extends Base
      * @param $id
      *
      * @return ShopifyLocation
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getById($id)
     {
@@ -45,9 +53,10 @@ class Location extends Base
     }
 
     /**
-     * @return int
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function count()
+    public function count(): int
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/locations/count.json");
 
@@ -57,9 +66,10 @@ class Location extends Base
     /**
      * @param $id
      *
-     * @return Collection
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getLocationInventoryLevels($id)
+    public function getLocationInventoryLevels($id): Collection
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/locations/$id/inventory_levels.json");
 

--- a/src/Services/OrderLineItem.php
+++ b/src/Services/OrderLineItem.php
@@ -3,9 +3,9 @@
 namespace BoldApps\ShopifyToolkit\Services;
 
 use BoldApps\ShopifyToolkit\Models\TaxLine as LineItemTaxLine;
+use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
 use BoldApps\ShopifyToolkit\Services\TaxLine as TaxLineService;
 use Illuminate\Support\Collection;
-use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
 
 class OrderLineItem extends Base
 {
@@ -25,8 +25,8 @@ class OrderLineItem extends Base
     /**
      * Order constructor.
      *
-     * @param Client         $client
-     * @param TaxLineService $taxLineService
+     * @param Client  $client
+     * @param TaxLine $taxLineService
      */
     public function __construct(ShopifyClient $client, TaxLineService $taxLineService)
     {

--- a/src/Services/PriceRule.php
+++ b/src/Services/PriceRule.php
@@ -2,7 +2,9 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\PriceRule as ShopifyPriceRule;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class PriceRule extends CollectionEntity
@@ -11,6 +13,9 @@ class PriceRule extends CollectionEntity
      * @param $id
      *
      * @return ShopifyPriceRule | object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function getById($id)
     {
@@ -20,16 +25,15 @@ class PriceRule extends CollectionEntity
     }
 
     /**
+     * @return Collection
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
+     *
      * @deprecated Use getByParams()
      * @see getByParams()
-     *
-     * @param int   $page
-     * @param int   $limit
-     * @param array $filter
-     *
-     * @return Collection
      */
-    public function getAll($page = 1, $limit = 50, $filter = [])
+    public function getAll(int $page = 1, int $limit = 50, array $filter = [])
     {
         $raw = $this->client->get('admin/price_rules.json', array_merge(['page' => $page, 'limit' => $limit], $filter));
 
@@ -41,11 +45,12 @@ class PriceRule extends CollectionEntity
     }
 
     /**
-     * @param array $params
-     *
      * @return Collection
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
-    public function getByParams($params)
+    public function getByParams(array $params)
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/price_rules.json", $params);
 
@@ -57,9 +62,10 @@ class PriceRule extends CollectionEntity
     }
 
     /**
-     * @param ShopifyPriceRule $priceRule
-     *
      * @return ShopifyPriceRule | object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function create(ShopifyPriceRule $priceRule)
     {
@@ -75,15 +81,16 @@ class PriceRule extends CollectionEntity
      *
      * @return object
      */
-    public function createFromArray($array)
+    public function createFromArray(array $array)
     {
         return $this->unserializeModel($array, ShopifyPriceRule::class);
     }
 
     /**
-     * @param ShopifyPriceRule $priceRule
-     *
      * @return ShopifyPriceRule | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function update(ShopifyPriceRule $priceRule)
     {
@@ -95,9 +102,10 @@ class PriceRule extends CollectionEntity
     }
 
     /**
-     * @param ShopifyPriceRule $priceRule
+     * @return array
      *
-     * @return ShopifyPriceRule | object
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function delete(ShopifyPriceRule $priceRule)
     {

--- a/src/Services/Product.php
+++ b/src/Services/Product.php
@@ -2,6 +2,7 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Image as ShopifyImage;
 use BoldApps\ShopifyToolkit\Models\Metafield as ShopifyMetafield;
 use BoldApps\ShopifyToolkit\Models\Option as ShopifyOption;
@@ -12,6 +13,7 @@ use BoldApps\ShopifyToolkit\Services\Image as ImageService;
 use BoldApps\ShopifyToolkit\Services\Metafield as MetafieldService;
 use BoldApps\ShopifyToolkit\Services\Option as OptionService;
 use BoldApps\ShopifyToolkit\Services\Variant as VariantService;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class Product extends CollectionEntity
@@ -49,11 +51,10 @@ class Product extends CollectionEntity
     /**
      * Product constructor.
      *
-     * @param Client           $client
-     * @param Variant          $variantService
-     * @param Option           $optionService
-     * @param Image            $imageService
-     * @param MetafieldService $metafieldService
+     * @param Client  $client
+     * @param Variant $variantService
+     * @param Option  $optionService
+     * @param Image   $imageService
      */
     public function __construct(
         ShopifyClient $client,
@@ -70,12 +71,12 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param ShopifyProduct $product
-     * @param bool           $publish
-     *
      * @return object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
-    public function create(ShopifyProduct $product, $publish = true)
+    public function create(ShopifyProduct $product, bool $publish = true)
     {
         $serializedModel = ['product' => array_merge($this->serializeModel($product), ['published' => $publish])];
 
@@ -85,12 +86,14 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param       $id
-     * @param array $filter
+     * @param $id
      *
      * @return ShopifyProduct | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getById($id, $filter = [])
+    public function getById($id, array $filter = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/products/$id.json", $filter);
 
@@ -100,16 +103,15 @@ class Product extends CollectionEntity
     }
 
     /**
+     * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
+     *
      * @deprecated Use getByParams()
      * @see getByParams()
-     *
-     * @param int   $page
-     * @param int   $limit
-     * @param array $filter
-     *
-     * @return Collection
      */
-    public function getAll($page = 1, $limit = 50, $filter = [])
+    public function getAll(int $page = 1, int $limit = 50, array $filter = [])
     {
         $raw = $this->client->get('admin/products.json', array_merge(['page' => $page, 'limit' => $limit], $filter));
 
@@ -121,11 +123,12 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param array $params
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getByParams($params)
+    public function getByParams(array $params)
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/products.json", $params);
 
@@ -137,12 +140,12 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param array $productIds
-     * @param array $filter
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getByProductIdArray($productIds, $filter = [])
+    public function getByProductIdArray(array $productIds, array $filter = [])
     {
         $products = [];
         $limit = 250;
@@ -170,9 +173,10 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param ShopifyProduct $product
-     *
      * @return object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function update(ShopifyProduct $product)
     {
@@ -184,9 +188,10 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param ShopifyProduct $product
-     *
      * @return array | null
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function delete(ShopifyProduct $product)
     {
@@ -194,11 +199,12 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param array $filter
-     *
      * @return int
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function count($filter = [])
+    public function count(array $filter = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/products/count.json", $filter);
 
@@ -206,20 +212,18 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param array $array
-     *
      * @return object
      */
-    public function createFromArray($array)
+    public function createFromArray(array $array)
     {
         return $this->unserializeModel($array, ShopifyProduct::class);
     }
 
     /**
-     * @param ShopifyProduct   $product
-     * @param ShopifyMetafield $metafield
-     *
      * @return ShopifyMetafield | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function createOrUpdateMetafield(ShopifyProduct $product, ShopifyMetafield $metafield)
     {
@@ -231,12 +235,12 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param ShopifyProduct $product
-     * @param array          $filter
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getMetafields(ShopifyProduct $product, $filter = [])
+    public function getMetafields(ShopifyProduct $product, array $filter = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/products/{$product->getId()}/metafields.json", $filter);
 
@@ -248,10 +252,12 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param                $id
-     * @param ShopifyProduct $product
+     * @param $id
      *
      * @return ShopifyMetafield | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getMetafield(ShopifyProduct $product, $id)
     {
@@ -261,10 +267,10 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param ShopifyProduct   $product
-     * @param ShopifyMetafield $metafield
-     *
      * @return array | null
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function deleteMetafield(ShopifyProduct $product, ShopifyMetafield $metafield)
     {
@@ -272,11 +278,12 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param int $metafieldId
-     *
      * @return array | null
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function deleteMetafieldById($metafieldId)
+    public function deleteMetafieldById(int $metafieldId)
     {
         return $this->client->delete("{$this->getApiBasePath()}/metafields/{$metafieldId}.json");
     }
@@ -302,11 +309,9 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param array $data
-     *
      * @return Collection | null
      */
-    protected function unserializeVariants($data)
+    protected function unserializeVariants(array $data)
     {
         if (null === $data) {
             return null;
@@ -340,11 +345,9 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param array $data
-     *
      * @return Collection | null
      */
-    protected function unserializeOptions($data)
+    protected function unserializeOptions(array $data)
     {
         if (null === $data) {
             return null;
@@ -372,11 +375,9 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param array $data
-     *
      * @return ShopifyImage | object
      */
-    protected function unserializeImage($data)
+    protected function unserializeImage(array $data)
     {
         if (null === $data) {
             return null;
@@ -406,11 +407,9 @@ class Product extends CollectionEntity
     }
 
     /**
-     * @param array $data
-     *
      * @return Collection | null
      */
-    protected function unserializeImages($data)
+    protected function unserializeImages(array $data)
     {
         if (null === $data) {
             return null;
@@ -448,7 +447,7 @@ class Product extends CollectionEntity
      *
      * @return Collection | null
      */
-    protected function unserializeMetafields($data)
+    protected function unserializeMetafields(array $data)
     {
         if (null === $data) {
             return null;

--- a/src/Services/RecurringApplicationCharge.php
+++ b/src/Services/RecurringApplicationCharge.php
@@ -2,15 +2,18 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\RecurringApplicationCharge as ShopifyRecurringApplicationCharge;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class RecurringApplicationCharge extends Base
 {
     /**
-     * @param ShopifyRecurringApplicationCharge $recurringApplicationCharge
-     *
      * @return ShopifyRecurringApplicationCharge \ object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function create(ShopifyRecurringApplicationCharge $recurringApplicationCharge)
     {
@@ -25,6 +28,9 @@ class RecurringApplicationCharge extends Base
      * @param $id
      *
      * @return ShopifyRecurringApplicationCharge \ object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function getById($id)
     {
@@ -34,7 +40,7 @@ class RecurringApplicationCharge extends Base
     }
 
     /**
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getAll()
     {
@@ -47,9 +53,10 @@ class RecurringApplicationCharge extends Base
     }
 
     /**
-     * @param ShopifyRecurringApplicationCharge $recurringApplicationCharge
-     *
      * @return ShopifyRecurringApplicationCharge \ object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function activate(ShopifyRecurringApplicationCharge $recurringApplicationCharge)
     {
@@ -62,19 +69,16 @@ class RecurringApplicationCharge extends Base
     }
 
     /**
-     * @param ShopifyRecurringApplicationCharge $recurringApplicationCharge
-     *
-     * @return array
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function delete(ShopifyRecurringApplicationCharge $recurringApplicationCharge)
+    public function delete(ShopifyRecurringApplicationCharge $recurringApplicationCharge): array
     {
         return $this->client->delete("{$this->getApiBasePath()}/recurring_application_charges/{$recurringApplicationCharge->getId()}.json");
     }
 
     /**
      * @param $array
-     *
-     * @return ShopifyRecurringApplicationCharge | object
      */
     public function createFromArray($array)
     {

--- a/src/Services/Refund.php
+++ b/src/Services/Refund.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Collection;
 class Refund extends Base
 {
     /**
-     * @var \BoldApps\ShopifyToolkit\Services\RefundLineItem
+     * @var RefundLineItem
      */
     protected $refundLineItemService;
 
@@ -52,9 +52,10 @@ class Refund extends Base
     ];
 
     /**
-     * @param ShopifyRefund $refund
-     *
      * @return ShopifyRefund | object
+     *
+     * @throws \BoldApps\ShopifyToolkit\Exceptions\ShopifyException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function create(ShopifyRefund $refund)
     {
@@ -66,9 +67,10 @@ class Refund extends Base
     }
 
     /**
-     * @param ShopifyRefund $refund
-     *
      * @return ShopifyRefund | object
+     *
+     * @throws \BoldApps\ShopifyToolkit\Exceptions\ShopifyException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function calculate(ShopifyRefund $refund)
     {
@@ -84,7 +86,7 @@ class Refund extends Base
      *
      * @return ShopifyRefund | object
      */
-    public function createFromArray($array)
+    public function createFromArray(array $array)
     {
         return $this->unserializeModel($array, ShopifyRefund::class);
     }

--- a/src/Services/Script.php
+++ b/src/Services/Script.php
@@ -2,15 +2,18 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Script as ShopifyScript;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class Script extends Base
 {
     /**
-     * @param ShopifyScript $script
-     *
      * @return object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function create(ShopifyScript $script)
     {
@@ -23,6 +26,9 @@ class Script extends Base
 
     /**
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function get()
     {
@@ -39,6 +45,9 @@ class Script extends Base
      * @param $url
      *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getByUrl($url)
     {
@@ -52,9 +61,10 @@ class Script extends Base
     }
 
     /**
-     * @param ShopifyScript $script
-     *
      * @return object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function update(ShopifyScript $script)
     {
@@ -66,9 +76,10 @@ class Script extends Base
     }
 
     /**
-     * @param ShopifyScript $script
-     *
      * @return array
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function delete(ShopifyScript $script)
     {

--- a/src/Services/Shop.php
+++ b/src/Services/Shop.php
@@ -2,14 +2,19 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Metafield as ShopifyMetafield;
 use BoldApps\ShopifyToolkit\Models\Shop as ShopifyShop;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class Shop extends Base
 {
     /**
      * @return ShopifyShop
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function get()
     {
@@ -18,6 +23,9 @@ class Shop extends Base
 
     /**
      * @return mixed
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function asArray()
     {
@@ -27,10 +35,10 @@ class Shop extends Base
     }
 
     /**
-     * @param ShopifyShop      $shop
-     * @param ShopifyMetafield $metafield
-     *
      * @return ShopifyMetafield | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function createOrUpdateMetafield(ShopifyShop $shop, ShopifyMetafield $metafield)
     {
@@ -42,9 +50,10 @@ class Shop extends Base
     }
 
     /**
-     * @param ShopifyMetafield $metafield
-     *
      * @return ShopifyMetafield | object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getMetafield(ShopifyMetafield $metafield)
     {
@@ -54,9 +63,10 @@ class Shop extends Base
     }
 
     /**
-     * @param array $params
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getMetafields(array $params = [])
     {
@@ -70,9 +80,10 @@ class Shop extends Base
     }
 
     /**
-     * @param ShopifyMetafield $metafield
+     * @return array
      *
-     * @return Collection
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function deleteMetafield(ShopifyMetafield $metafield)
     {

--- a/src/Services/SmartCollection.php
+++ b/src/Services/SmartCollection.php
@@ -2,11 +2,13 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
+use BoldApps\ShopifyToolkit\Models\Product as ShopifyProduct;
+use BoldApps\ShopifyToolkit\Models\SmartCollection as ShopifySmartCollection;
 use BoldApps\ShopifyToolkit\Models\SmartCollectionRule as ShopifySmartCollectionRule;
 use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
-use BoldApps\ShopifyToolkit\Models\SmartCollection as ShopifySmartCollection;
 use BoldApps\ShopifyToolkit\Services\SmartCollectionRule as SmartCollectionRuleService;
-use BoldApps\ShopifyToolkit\Models\Product as ShopifyProduct;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class SmartCollection extends CollectionEntity
@@ -14,12 +16,6 @@ class SmartCollection extends CollectionEntity
     /** @var SmartCollectionRuleService */
     protected $ruleService;
 
-    /**
-     * SmartCollection constructor.
-     *
-     * @param Client                     $client
-     * @param SmartCollectionRuleService $ruleService
-     */
     public function __construct(
         ShopifyClient $client,
         SmartCollectionRuleService $ruleService
@@ -43,12 +39,12 @@ class SmartCollection extends CollectionEntity
     ];
 
     /**
-     * @param ShopifySmartCollection $collection
-     * @param bool                   $publish
-     *
      * @return object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
-    public function create(ShopifySmartCollection $collection, $publish = true)
+    public function create(ShopifySmartCollection $collection, bool $publish = true)
     {
         $serializedModel = [
             'smart_collection' => array_merge($this->serializeModel($collection), ['published' => $publish]),
@@ -64,7 +60,7 @@ class SmartCollection extends CollectionEntity
      *
      * @return ShopifySmartCollection | object
      */
-    public function createFromArray($array)
+    public function createFromArray(array $array)
     {
         return $this->unserializeModel($array, ShopifySmartCollection::class);
     }
@@ -73,6 +69,9 @@ class SmartCollection extends CollectionEntity
      * @param $id
      *
      * @return ShopifySmartCollection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getById($id)
     {
@@ -82,12 +81,12 @@ class SmartCollection extends CollectionEntity
     }
 
     /**
-     * @param int   $id
-     * @param array $filter
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getProductsBySmartCollectionId($id, $filter = [])
+    public function getProductsBySmartCollectionId(int $id, array $filter = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/collections/$id/products.json", $filter);
 
@@ -99,16 +98,15 @@ class SmartCollection extends CollectionEntity
     }
 
     /**
+     * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
+     *
      * @deprecated Use getByParams()
      * @see getByParams()
-     *
-     * @param int   $page
-     * @param int   $limit
-     * @param array $filter
-     *
-     * @return Collection
      */
-    public function getAll($page = 1, $limit = 50, $filter = [])
+    public function getAll(int $page = 1, int $limit = 50, array $filter = [])
     {
         $raw = $this->client->get('admin/smart_collections.json',
             array_merge(['page' => $page, 'limit' => $limit], $filter));
@@ -123,9 +121,9 @@ class SmartCollection extends CollectionEntity
     /**
      * @param $params
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
-    public function getByParams($params)
+    public function getByParams(array $params)
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/smart_collections.json", $params);
 
@@ -137,9 +135,10 @@ class SmartCollection extends CollectionEntity
     }
 
     /**
-     * @param ShopifySmartCollection $collection
-     *
      * @return object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function update(ShopifySmartCollection $collection)
     {
@@ -151,9 +150,10 @@ class SmartCollection extends CollectionEntity
     }
 
     /**
-     * @param ShopifySmartCollection $collection
-     *
      * @return array
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function delete(ShopifySmartCollection $collection)
     {
@@ -161,11 +161,12 @@ class SmartCollection extends CollectionEntity
     }
 
     /**
-     * @param array $filter
-     *
      * @return int
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function count($filter = [])
+    public function count(array $filter = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/smart_collections/count.json", $filter);
 
@@ -173,11 +174,12 @@ class SmartCollection extends CollectionEntity
     }
 
     /**
-     * @param $filter
-     *
      * @return int
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function countByParams($filter = [])
+    public function countByParams(array $filter = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/smart_collections/count.json", $filter);
 
@@ -207,11 +209,9 @@ class SmartCollection extends CollectionEntity
     }
 
     /**
-     * @param array $data
-     *
      * @return Collection
      */
-    protected function unserializeRules($data)
+    protected function unserializeRules(array $data)
     {
         if (null === $data) {
             return;

--- a/src/Services/Theme.php
+++ b/src/Services/Theme.php
@@ -2,15 +2,18 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
-use Illuminate\Support\Collection;
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Theme as ShopifyTheme;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Collection;
 
 class Theme extends Base
 {
     /**
-     * @param ShopifyTheme $shopifyTheme
-     *
      * @return ShopifyTheme
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function create(ShopifyTheme $shopifyTheme)
     {
@@ -22,9 +25,10 @@ class Theme extends Base
     }
 
     /**
-     * @param ShopifyTheme $shopifyTheme
-     *
      * @return ShopifyTheme
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function update(ShopifyTheme $shopifyTheme)
     {
@@ -40,6 +44,9 @@ class Theme extends Base
      * @param $id
      *
      * @return ShopifyTheme
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getById($id)
     {
@@ -50,6 +57,9 @@ class Theme extends Base
 
     /**
      * @return ShopifyTheme
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getMain()
     {
@@ -61,14 +71,15 @@ class Theme extends Base
     }
 
     /**
+     * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
+     *
      * @deprecated Use getByParams()
      * @see getByParams()
-     *
-     * @param array $filter
-     *
-     * @return Collection
      */
-    public function getAll($filter = [])
+    public function getAll(array $filter = [])
     {
         $raw = $this->client->get('admin/themes.json', $filter);
 
@@ -80,11 +91,12 @@ class Theme extends Base
     }
 
     /**
-     * @param array $params
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getByParams($params = [])
+    public function getByParams(array $params = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/themes.json", $params);
 

--- a/src/Services/UsageCharge.php
+++ b/src/Services/UsageCharge.php
@@ -2,15 +2,19 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\UsageCharge as ShopifyUsageCharge;
+use GuzzleHttp\Exception\GuzzleException;
 
 class UsageCharge extends Base
 {
     /**
      * @param $recurringChargeId
-     * @param ShopifyUsageCharge $usageCharge
      *
      * @return object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function create($recurringChargeId, ShopifyUsageCharge $usageCharge)
     {
@@ -25,6 +29,9 @@ class UsageCharge extends Base
      * @param $recurringChargeId
      *
      * @return object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function getById($recurringChargeId)
     {

--- a/src/Services/Variant.php
+++ b/src/Services/Variant.php
@@ -2,18 +2,20 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Metafield as ShopifyMetafield;
 use BoldApps\ShopifyToolkit\Models\Product as ShopifyProduct;
 use BoldApps\ShopifyToolkit\Models\Variant as ShopifyVariant;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class Variant extends Base
 {
     /**
-     * @param ShopifyProduct $product
-     * @param ShopifyVariant $variant
-     *
      * @return object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function create(ShopifyProduct $product, ShopifyVariant $variant)
     {
@@ -38,6 +40,9 @@ class Variant extends Base
      * @param $id
      *
      * @return ShopifyVariant
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function getById($id)
     {
@@ -47,12 +52,12 @@ class Variant extends Base
     }
 
     /**
-     * @param int   $productId
-     * @param array $filter
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getAllByProductId($productId, $filter = [])
+    public function getAllByProductId(int $productId, array $filter = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/products/$productId/variants.json", $filter);
 
@@ -64,9 +69,10 @@ class Variant extends Base
     }
 
     /**
-     * @param ShopifyVariant $variant
-     *
      * @return object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function update(ShopifyVariant $variant)
     {
@@ -78,10 +84,10 @@ class Variant extends Base
     }
 
     /**
-     * @param ShopifyProduct $product
-     * @param ShopifyVariant $variant
+     * @return array
      *
-     * @return object
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function delete(ShopifyProduct $product, ShopifyVariant $variant)
     {
@@ -89,11 +95,11 @@ class Variant extends Base
     }
 
     /**
-     * @param ShopifyVariant   $variant
-     * @param ShopifyMetafield $metafield
-     *
      * @return Collection
-     **/
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
+     */
     public function createMetafield(ShopifyVariant $variant, ShopifyMetafield $metafield)
     {
         $serializedModel = ['metafield' => array_merge($this->serializeModel($metafield))];
@@ -104,10 +110,10 @@ class Variant extends Base
     }
 
     /**
-     * @param ShopifyVariant   $variant
-     * @param ShopifyMetafield $metafield
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function updateMetafield(ShopifyVariant $variant, ShopifyMetafield $metafield)
     {
@@ -119,12 +125,12 @@ class Variant extends Base
     }
 
     /**
-     * @param ShopifyVariant $variant
-     * @param array          $params
-     *
      * @return Collection
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
-    public function getMetafields(ShopifyVariant $variant, $params = [])
+    public function getMetafields(ShopifyVariant $variant, array $params = [])
     {
         $raw = $this->client->get("{$this->getApiBasePath()}/variants/{$variant->getId()}/metafields.json", $params);
 
@@ -136,10 +142,10 @@ class Variant extends Base
     }
 
     /**
-     * @param ShopifyVariant   $variant
-     * @param ShopifyMetafield $metafield
+     * @return array
      *
-     * @return Collection
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function deleteMetafield(ShopifyVariant $variant, ShopifyMetafield $metafield)
     {
@@ -147,9 +153,10 @@ class Variant extends Base
     }
 
     /**
-     * @param ShopifyMetafield $metafield
+     * @return array
      *
-     * @return Collection
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function deleteMetafieldById(ShopifyMetafield $metafield)
     {
@@ -157,11 +164,9 @@ class Variant extends Base
     }
 
     /**
-     * @param ShopifyVariant $variant
-     *
      * @return array
      */
-    public function serializeVariantCreateUpdate($variant)
+    public function serializeVariantCreateUpdate(ShopifyVariant $variant)
     {
         $serializedModel = $this->serializeModel($variant);
 

--- a/src/Services/Webhook.php
+++ b/src/Services/Webhook.php
@@ -2,15 +2,18 @@
 
 namespace BoldApps\ShopifyToolkit\Services;
 
+use BoldApps\ShopifyToolkit\Exceptions\ShopifyException;
 use BoldApps\ShopifyToolkit\Models\Webhook as ShopifyWebhook;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Collection;
 
 class Webhook extends Base
 {
     /**
-     * @param ShopifyWebhook $webhook
-     *
      * @return object
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function create(ShopifyWebhook $webhook)
     {
@@ -23,6 +26,9 @@ class Webhook extends Base
 
     /**
      * @return Collection
+     *
+     * @throws ShopifyException
+     * @throws GuzzleException
      */
     public function get()
     {
@@ -36,9 +42,10 @@ class Webhook extends Base
     }
 
     /**
-     * @param ShopifyWebhook $webhook
-     *
      * @return object
+     *
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function update(ShopifyWebhook $webhook)
     {
@@ -50,9 +57,10 @@ class Webhook extends Base
     }
 
     /**
-     * @param ShopifyWebhook $webhook
+     * @return array
      *
-     * @return null|object
+     * @throws GuzzleException
+     * @throws ShopifyException
      */
     public function delete(ShopifyWebhook $webhook)
     {

--- a/src/Support/ShopifyApiHandler.php
+++ b/src/Support/ShopifyApiHandler.php
@@ -2,12 +2,13 @@
 
 namespace BoldApps\ShopifyToolkit\Support;
 
-use BoldApps\ShopifyToolkit\Contracts\RequestHookInterface;
 use BoldApps\ShopifyToolkit\Contracts\ApiSleeper;
+use BoldApps\ShopifyToolkit\Contracts\RequestHookInterface;
+use GuzzleHttp\Psr7\Response;
 
 class ShopifyApiHandler implements RequestHookInterface, ApiSleeper
 {
-    /** @var \GuzzleHttp\Psr7\Response|null */
+    /** @var Response|null */
     private $response;
 
     /**
@@ -18,7 +19,7 @@ class ShopifyApiHandler implements RequestHookInterface, ApiSleeper
     }
 
     /**
-     * @param \GuzzleHttp\Psr7\Response|null $response
+     * @param Response|null $response
      */
     public function afterRequest($response)
     {
@@ -26,7 +27,7 @@ class ShopifyApiHandler implements RequestHookInterface, ApiSleeper
     }
 
     /**
-     * @param \GuzzleHttp\Psr7\Response|null $response
+     * @param Response|null $response
      */
     public function sleep($response)
     {
@@ -48,10 +49,7 @@ class ShopifyApiHandler implements RequestHookInterface, ApiSleeper
         }
     }
 
-    /**
-     * @return int
-     */
-    private function getCallLimitPercent()
+    private function getCallLimitPercent(): int
     {
         $callLimitRatio = $this->getCallLimitRatio();
         $callsMade = $callLimitRatio[0];
@@ -64,10 +62,7 @@ class ShopifyApiHandler implements RequestHookInterface, ApiSleeper
         return $callsMade / $callLimit * 100;
     }
 
-    /**
-     * @return array
-     */
-    private function getCallLimitRatio()
+    private function getCallLimitRatio(): array
     {
         if (null !== $this->response) {
             $callLimitHeader = $this->response->getHeader('http_x_shopify_shop_api_call_limit');
@@ -77,6 +72,6 @@ class ShopifyApiHandler implements RequestHookInterface, ApiSleeper
             }
         }
 
-        return array(1, 100);
+        return [1, 100];
     }
 }

--- a/tests/CollectTest.php
+++ b/tests/CollectTest.php
@@ -3,13 +3,14 @@
 use BoldApps\ShopifyToolkit\Models\Collect as ShopifyCollect;
 use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\Collect as CollectService;
+use PHPUnit\Framework\TestCase;
 
-class CollectTest extends \PHPUnit\Framework\TestCase
+class CollectTest extends TestCase
 {
     /** @var CollectService */
     private $collectService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -19,7 +20,7 @@ class CollectTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyCollectSerializesProperly()
+    public function shopifyCollectSerializesProperly()
     {
         $collectEntity = $this->createCollectEntity();
 
@@ -32,7 +33,7 @@ class CollectTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyCollectDeserializesProperly()
+    public function shopifyCollectDeserializesProperly()
     {
         $collectJson = $this->getCollectJson();
         $jsonArray = (array) json_decode($collectJson, true);

--- a/tests/CountryTest.php
+++ b/tests/CountryTest.php
@@ -1,15 +1,16 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Models\Country as ShopifyCountry;
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\Country as CountryService;
+use PHPUnit\Framework\TestCase;
 
-class CountryTest extends \PHPUnit\Framework\TestCase
+class CountryTest extends TestCase
 {
     /** @var CountryService */
     private $countryService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -19,7 +20,7 @@ class CountryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyCountrySerializesProperly()
+    public function shopifyCountrySerializesProperly()
     {
         $countryEntity = $this->createCountryEntity();
 
@@ -32,7 +33,7 @@ class CountryTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyCountryDeserializesProperly()
+    public function shopifyCountryDeserializesProperly()
     {
         $countryJson = $this->getCountryJson();
         $jsonArray = (array) json_decode($countryJson, true);

--- a/tests/CustomerSavedSearchTest.php
+++ b/tests/CustomerSavedSearchTest.php
@@ -1,15 +1,16 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Models\CustomerSavedSearch as ShopifyCustomerSavedSearch;
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\CustomerSavedSearch as CustomerSavedSearchService;
+use PHPUnit\Framework\TestCase;
 
-class CustomerSavedSearchTest extends \PHPUnit\Framework\TestCase
+class CustomerSavedSearchTest extends TestCase
 {
     /** @var CustomerSavedSearchService */
     private $customerSavedSearchService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -19,7 +20,7 @@ class CustomerSavedSearchTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyCustomerSavedSearchSerializesProperly()
+    public function shopifyCustomerSavedSearchSerializesProperly()
     {
         $customerSavedSearchEntity = $this->createCustomerSavedSearchEntity();
 
@@ -32,7 +33,7 @@ class CustomerSavedSearchTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyCustomerSavedSearchDeserializesProperly()
+    public function shopifyCustomerSavedSearchDeserializesProperly()
     {
         $customerSavedSearchJson = $this->getCustomerSavedSearchJson();
         $jsonArray = (array) json_decode($customerSavedSearchJson, true);

--- a/tests/CustomerTest.php
+++ b/tests/CustomerTest.php
@@ -1,15 +1,16 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Models\Customer as ShopifyCustomer;
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\Customer as CustomerService;
+use PHPUnit\Framework\TestCase;
 
-class CustomerTest extends \PHPUnit\Framework\TestCase
+class CustomerTest extends TestCase
 {
     /** @var CustomerService */
     private $customerService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -19,7 +20,7 @@ class CustomerTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyCustomerSerializesProperly()
+    public function shopifyCustomerSerializesProperly()
     {
         $customerEntity = $this->createCustomerEntity();
 
@@ -32,7 +33,7 @@ class CustomerTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyCustomerDeserializesProperly()
+    public function shopifyCustomerDeserializesProperly()
     {
         $customerJson = $this->getCustomerJson();
         $jsonArray = (array) json_decode($customerJson, true);

--- a/tests/DiscountCodeTest.php
+++ b/tests/DiscountCodeTest.php
@@ -1,15 +1,16 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Models\DiscountCode as ShopifyDiscountCode;
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\DiscountCode as DiscountCodeService;
+use PHPUnit\Framework\TestCase;
 
-class DiscountCodeTest extends \PHPUnit\Framework\TestCase
+class DiscountCodeTest extends TestCase
 {
     /** @var DiscountCodeService */
     private $discountCodeService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -19,7 +20,7 @@ class DiscountCodeTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyDiscountCodeSerializesProperly()
+    public function shopifyDiscountCodeSerializesProperly()
     {
         $discountCodeEntity = $this->createDiscountCodeEntity();
 
@@ -32,7 +33,7 @@ class DiscountCodeTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyDiscountCodeDeserializesProperly()
+    public function shopifyDiscountCodeDeserializesProperly()
     {
         $discountCodeJson = $this->getDiscountCodeJson();
         $jsonArray = (array) json_decode($discountCodeJson, true);

--- a/tests/FulfillmentTest.php
+++ b/tests/FulfillmentTest.php
@@ -1,15 +1,16 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Models\Fulfillment as ShopifyFulfillment;
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\Fulfillment as FulfillmentService;
+use PHPUnit\Framework\TestCase;
 
-class FulfillmentTest extends \PHPUnit\Framework\TestCase
+class FulfillmentTest extends TestCase
 {
     /** @var FulfillmentService */
     private $fulfillmentService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -19,7 +20,7 @@ class FulfillmentTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyFulfillmentSerializesProperly()
+    public function shopifyFulfillmentSerializesProperly()
     {
         $fulfillmentEntity = $this->createFulfillmentEntity();
 
@@ -32,7 +33,7 @@ class FulfillmentTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyFulfillmentDeserializesProperly()
+    public function shopifyFulfillmentDeserializesProperly()
     {
         $fulfillmentJson = $this->getFulfillmentJson();
         $jsonArray = (array) json_decode($fulfillmentJson, true);

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -1,15 +1,16 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Models\Image as ShopifyImage;
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\Image as ImageService;
+use PHPUnit\Framework\TestCase;
 
-class ImageTest extends \PHPUnit\Framework\TestCase
+class ImageTest extends TestCase
 {
     /** @var ImageService */
     private $imageService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -19,7 +20,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyImageSerializesProperly()
+    public function shopifyImageSerializesProperly()
     {
         $imageEntity = $this->imageService->createFromArray($this->getImageArray());
 
@@ -32,7 +33,7 @@ class ImageTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyImageDeserializesProperly()
+    public function shopifyImageDeserializesProperly()
     {
         $imageJson = $this->getImageJson();
         $jsonArray = (array) json_decode($imageJson, true);

--- a/tests/InventoryLevelTest.php
+++ b/tests/InventoryLevelTest.php
@@ -1,15 +1,16 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Models\InventoryLevel as ShopifyInventoryLevel;
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\InventoryLevel as InventoryLevelService;
+use PHPUnit\Framework\TestCase;
 
-class InventoryLevelTest extends \PHPUnit\Framework\TestCase
+class InventoryLevelTest extends TestCase
 {
     /** @var InventoryLevelService */
     private $inventoryLevelService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -19,7 +20,7 @@ class InventoryLevelTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyInventoryLevelSerializesProperly()
+    public function shopifyInventoryLevelSerializesProperly()
     {
         $inventoryLevelEntity = $this->inventoryLevelService->createFromArray($this->getInventoryLevelArray());
 
@@ -32,7 +33,7 @@ class InventoryLevelTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyInventoryLevelDeserializesProperly()
+    public function shopifyInventoryLevelDeserializesProperly()
     {
         $inventoryLevelJson = $this->getInventoryLevelJson();
         $jsonArray = (array) json_decode($inventoryLevelJson, true);

--- a/tests/LocationTest.php
+++ b/tests/LocationTest.php
@@ -1,15 +1,16 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Models\Location as ShopifyLocation;
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\Location as LocationService;
+use PHPUnit\Framework\TestCase;
 
-class LocationTest extends \PHPUnit\Framework\TestCase
+class LocationTest extends TestCase
 {
     /** @var LocationService */
     private $locationService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -19,7 +20,7 @@ class LocationTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyLocationSerializesProperly()
+    public function shopifyLocationSerializesProperly()
     {
         $locationEntity = $this->locationService->createFromArray($this->getLocationArray());
 
@@ -32,7 +33,7 @@ class LocationTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyLocationDeserializesProperly()
+    public function shopifyLocationDeserializesProperly()
     {
         $locationJson = $this->getLocationJson();
         $jsonArray = (array) json_decode($locationJson, true);

--- a/tests/PriceRuleTest.php
+++ b/tests/PriceRuleTest.php
@@ -1,15 +1,16 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Models\PriceRule as ShopifyPriceRule;
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\PriceRule as PriceRuleService;
+use PHPUnit\Framework\TestCase;
 
-class PriceRuleTest extends \PHPUnit\Framework\TestCase
+class PriceRuleTest extends TestCase
 {
     /** @var PriceRuleService */
     private $priceRuleService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -19,7 +20,7 @@ class PriceRuleTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyPriceRuleSerializesProperly()
+    public function shopifyPriceRuleSerializesProperly()
     {
         $priceRuleEntity = $this->priceRuleService->createFromArray($this->getPriceRuleArray());
 
@@ -32,7 +33,7 @@ class PriceRuleTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyPriceRuleDeserializesProperly()
+    public function shopifyPriceRuleDeserializesProperly()
     {
         $priceRuleJson = $this->getPriceRuleJson();
         $jsonArray = (array) json_decode($priceRuleJson, true);
@@ -96,19 +97,19 @@ class PriceRuleTest extends \PHPUnit\Framework\TestCase
             'ends_at' => '2017-09-18T16:23:01-04:00',
             'created_at' => '2017-09-12T16:23:01-04:00',
             'updated_at' => '2017-09-12T16:23:01-04:00',
-            'entitled_product_ids' => array(),
-            'entitled_variant_ids' => array(),
-            'entitled_collection_ids' => array(),
-            'entitled_country_ids' => array(),
-            'prerequisite_saved_search_ids' => array(),
-            'prerequisite_customer_ids' => array(),
-            'prerequisite_product_ids' => array(),
-            'prerequisite_variant_ids' => array(),
-            'prerequisite_collection_ids' => array(),
-            'prerequisite_subtotal_range' => array('greater_than_or_equal_to' => '10.0'),
-            'prerequisite_quantity_range' => array('greater_than_or_equal_to' => 5),
-            'prerequisite_shipping_price_range' => array('less_than_or_equal_to' => '17.0'),
-            'prerequisite_to_entitlement_quantity_ratio' => array('prerequisite_quantity' => 1, 'entitled_quantity' => 2),
+            'entitled_product_ids' => [],
+            'entitled_variant_ids' => [],
+            'entitled_collection_ids' => [],
+            'entitled_country_ids' => [],
+            'prerequisite_saved_search_ids' => [],
+            'prerequisite_customer_ids' => [],
+            'prerequisite_product_ids' => [],
+            'prerequisite_variant_ids' => [],
+            'prerequisite_collection_ids' => [],
+            'prerequisite_subtotal_range' => ['greater_than_or_equal_to' => '10.0'],
+            'prerequisite_quantity_range' => ['greater_than_or_equal_to' => 5],
+            'prerequisite_shipping_price_range' => ['less_than_or_equal_to' => '17.0'],
+            'prerequisite_to_entitlement_quantity_ratio' => ['prerequisite_quantity' => 1, 'entitled_quantity' => 2],
             'title' => 'WINTER SALE',
         ];
     }

--- a/tests/ProductTest.php
+++ b/tests/ProductTest.php
@@ -7,8 +7,9 @@ use BoldApps\ShopifyToolkit\Services\Metafield as MetafieldService;
 use BoldApps\ShopifyToolkit\Services\Option as OptionService;
 use BoldApps\ShopifyToolkit\Services\Product as ProductService;
 use BoldApps\ShopifyToolkit\Services\Variant as VariantService;
+use PHPUnit\Framework\TestCase;
 
-class ProductTest extends \PHPUnit\Framework\TestCase
+class ProductTest extends TestCase
 {
     /** @var ProductService */
     private $productService;
@@ -25,7 +26,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
     /** @var MetafieldService */
     private $metafieldService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -47,7 +48,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyProductSerializesProperly()
+    public function shopifyProductSerializesProperly()
     {
         /** @var ShopifyProduct $productEntity */
         $productEntity = $this->productService->createFromArray($this->getProductArray());
@@ -61,7 +62,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyProductDeserializesProperly()
+    public function shopifyProductDeserializesProperly()
     {
         $productJson = $this->getProductJson();
         $jsonArray = (array) json_decode($productJson, true);

--- a/tests/RecurringApplicationChargeTest.php
+++ b/tests/RecurringApplicationChargeTest.php
@@ -1,15 +1,16 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Models\RecurringApplicationCharge;
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\RecurringApplicationCharge as RecurringApplicationChargeService;
+use PHPUnit\Framework\TestCase;
 
-class RecurringApplicationChargeTest extends \PHPUnit\Framework\TestCase
+class RecurringApplicationChargeTest extends TestCase
 {
     /** @var RecurringApplicationChargeService */
     private $recurringApplicationChargeService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -19,7 +20,7 @@ class RecurringApplicationChargeTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyRecurringApplicationChargeSerializesProperly()
+    public function shopifyRecurringApplicationChargeSerializesProperly()
     {
         $recurringApplicationChargeEntity = $this->createRecurringApplicationChargeEntity();
 
@@ -33,7 +34,7 @@ class RecurringApplicationChargeTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyRecurringApplicationChargeDeserializesProperly()
+    public function shopifyRecurringApplicationChargeDeserializesProperly()
     {
         $recurringApplicationChargeJson = $this->getRecurringApplicationChargeJson();
         $jsonArray = (array) json_decode($recurringApplicationChargeJson, true);

--- a/tests/RefundTest.php
+++ b/tests/RefundTest.php
@@ -1,19 +1,19 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-use BoldApps\ShopifyToolkit\Models\Refund as ShopifyRefund;
-use BoldApps\ShopifyToolkit\Services\Refund as RefundService;
-use BoldApps\ShopifyToolkit\Models\Transaction;
 use BoldApps\ShopifyToolkit\Models\OrderAdjustment;
+use BoldApps\ShopifyToolkit\Models\Refund as ShopifyRefund;
 use BoldApps\ShopifyToolkit\Models\RefundLineItem;
+use BoldApps\ShopifyToolkit\Models\Transaction;
+use BoldApps\ShopifyToolkit\Services\Refund as RefundService;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase;
 
 class RefundTest extends TestCase
 {
     /** @var RefundService */
     private $refundService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $client = $this->createMock(\BoldApps\ShopifyToolkit\Services\Client::class);
         $refundLineItemService = new \BoldApps\ShopifyToolkit\Services\RefundLineItem($client);
@@ -24,7 +24,7 @@ class RefundTest extends TestCase
     /**
      * @test
      */
-    public function ShopifyRefundSerializesProperly()
+    public function shopifyRefundSerializesProperly()
     {
         $refundEntity = new ShopifyRefund();
         $refundEntity->setOrderId(123456);
@@ -98,7 +98,7 @@ class RefundTest extends TestCase
     /**
      * @test
      */
-    public function ShopifyRefundDeserializesProperly()
+    public function shopifyRefundDeserializesProperly()
     {
         $refundJson = '{
             "id": 929361464,

--- a/tests/Services/CartTest.php
+++ b/tests/Services/CartTest.php
@@ -2,9 +2,9 @@
 
 namespace BoldApps\Common\Test\Services\Shopify;
 
+use BoldApps\ShopifyToolkit\Models\Cart\Cart as CartModel;
 use BoldApps\ShopifyToolkit\Services\Cart;
 use BoldApps\ShopifyToolkit\Services\Client as ShopifyClient;
-use BoldApps\ShopifyToolkit\Models\Cart\Cart as CartModel;
 use GuzzleHttp\Client as HttpClient;
 use PHPUnit\Framework\TestCase;
 
@@ -13,7 +13,7 @@ class CartTest extends TestCase
     /** @var HttpClient */
     private $client;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->client = $this->getMockBuilder(HttpClient::class)->getMock();
     }

--- a/tests/Services/ClientTest.php
+++ b/tests/Services/ClientTest.php
@@ -35,7 +35,7 @@ class ClientTest extends TestCase
     /** @var string */
     protected $myShopifyDomain;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->myShopifyDomain = 'fight-club.myshopify.com';
 
@@ -93,7 +93,7 @@ class ClientTest extends TestCase
     }
 
     /**
-     * @param null|string $expected
+     * @param string|null $expected
      * @param int         $responseCode
      * @param array       $responseHeader
      * @param mixed       $exceptionClass
@@ -255,7 +255,7 @@ class ClientTest extends TestCase
             $this->mockRequestHookInterface
         );
 
-        $this->callMethod($this->client, 'parsePageInfo', array($linkHeader));
+        $this->callMethod($this->client, 'parsePageInfo', [$linkHeader]);
 
         $pageInfo = $this->client->getPageInfo();
 
@@ -294,7 +294,7 @@ class ClientTest extends TestCase
             $this->mockRequestHookInterface
         );
 
-        $parsedLinks = $this->callMethod($this->client, 'parseHeader', array($linkHeader));
+        $parsedLinks = $this->callMethod($this->client, 'parseHeader', [$linkHeader]);
 
         $this->assertEquals($expectedHeaderLinks, $parsedLinks);
     }
@@ -302,7 +302,6 @@ class ClientTest extends TestCase
     /**
      * @param object $obj
      * @param string $name
-     * @param array  $args
      *
      * @return mixed
      *
@@ -373,7 +372,7 @@ class ClientTest extends TestCase
             [
                 'expected' => null,
                 'responseCode' => 303,
-                'responseHeader' => ['Location' => []],
+                'responseHeader' => ['Location' => null],
                 'exceptionClass' => null,
             ],
             [

--- a/tests/Services/InstallAndLoginTest.php
+++ b/tests/Services/InstallAndLoginTest.php
@@ -4,14 +4,15 @@ namespace BoldApps\Common\Test\Services\Shopify;
 
 use BoldApps\ShopifyToolkit\Contracts\ApplicationInfo;
 use BoldApps\ShopifyToolkit\Contracts\ShopBaseInfo;
+use BoldApps\ShopifyToolkit\Exceptions\BadRequestException;
 use BoldApps\ShopifyToolkit\Services\InstallAndLogin;
 use GuzzleHttp\Client as HttpClient;
-use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 class InstallAndLoginTest extends TestCase
 {
@@ -24,7 +25,7 @@ class InstallAndLoginTest extends TestCase
     /** @var HttpClient */
     protected $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->applicationMock = $this->getMockBuilder(ApplicationInfo::class)->getMock();
         $this->shopBaseInfoMock = $this->getMockBuilder(ShopBaseInfo::class)->getMock();
@@ -74,11 +75,10 @@ class InstallAndLoginTest extends TestCase
         $this->assertEquals('abcdefedgegeadfasdfasdasf', $code);
     }
 
-    /**
-     * @expectedException \BoldApps\ShopifyToolkit\Exceptions\BadRequestException
-     */
     public function testGetAccessTokenBadToken()
     {
+        $this->expectException(BadRequestException::class);
+
         $mock = new MockHandler([
             new RequestException('Error Communicating with Server', new Request('GET', 'test'), new Response(400)),
         ]);

--- a/tests/Services/OrderTest.php
+++ b/tests/Services/OrderTest.php
@@ -5,8 +5,8 @@ namespace BoldApps\ShopifyToolkit\Test\Services;
 use BoldApps\ShopifyToolkit\Models\CancelOrder;
 use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\Order as OrderService;
-use BoldApps\ShopifyToolkit\Services\TaxLine as TaxLineService;
 use BoldApps\ShopifyToolkit\Services\OrderLineItem as OrderLineItemService;
+use BoldApps\ShopifyToolkit\Services\TaxLine as TaxLineService;
 use PHPUnit\Framework\TestCase;
 
 class OrderTest extends TestCase
@@ -14,7 +14,7 @@ class OrderTest extends TestCase
     /** @var OrderService */
     private $orderService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $client = $this->createMock(Client::class);
         $taxLineService = new TaxLineService($client);

--- a/tests/ShopifyBaseServiceTest.php
+++ b/tests/ShopifyBaseServiceTest.php
@@ -2,11 +2,12 @@
 
 namespace BoldApps\Common\Test\Services\Shopify;
 
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Test\Fakes\FakeBase;
 use BoldApps\ShopifyToolkit\Test\Fakes\FakeModel;
-use BoldApps\ShopifyToolkit\Services\Client;
+use PHPUnit\Framework\TestCase;
 
-class ShopifyBaseServiceTest extends \PHPUnit_Framework_TestCase
+class ShopifyBaseServiceTest extends TestCase
 {
     /** @test */
     public function unserializeModel()

--- a/tests/SmartCollectionTest.php
+++ b/tests/SmartCollectionTest.php
@@ -4,8 +4,9 @@ use BoldApps\ShopifyToolkit\Models\SmartCollection as ShopifySmartCollection;
 use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\SmartCollection as SmartCollectionService;
 use BoldApps\ShopifyToolkit\Services\SmartCollectionRule as SmartCollectionRuleService;
+use PHPUnit\Framework\TestCase;
 
-class SmartCollectionTest extends \PHPUnit\Framework\TestCase
+class SmartCollectionTest extends TestCase
 {
     /** @var SmartCollectionService */
     private $smartCollectionService;
@@ -13,7 +14,7 @@ class SmartCollectionTest extends \PHPUnit\Framework\TestCase
     /** @var SmartCollectionRuleService */
     private $smartCollectionRuleService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -24,7 +25,7 @@ class SmartCollectionTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifySmartCollectionSerializesProperly()
+    public function shopifySmartCollectionSerializesProperly()
     {
         $smartCollectionEntity = $this->createSmartCollectionEntity();
 
@@ -37,7 +38,7 @@ class SmartCollectionTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifySmartCollectionDeserializesProperly()
+    public function shopifySmartCollectionDeserializesProperly()
     {
         $smartCollectionJson = $this->getSmartCollectionJson();
         $jsonArray = (array) json_decode($smartCollectionJson, true);

--- a/tests/Traits/HasAttributesTraitTest.php
+++ b/tests/Traits/HasAttributesTraitTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Models\Cart\Item as CartItem;
 use BoldApps\ShopifyToolkit\Models\Cart\Cart;
+use BoldApps\ShopifyToolkit\Models\Cart\Item as CartItem;
 use BoldApps\ShopifyToolkit\Services\Cart as CartService;
 use BoldApps\ShopifyToolkit\Services\Client;
 
@@ -10,7 +10,7 @@ class HasAttributesTraitTest extends \PHPUnit\Framework\TestCase
     /** @var \BoldApps\ShopifyToolkit\Models\Customer */
     private $customerObject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $client = $this->createMock(Client::class);
         $this->cartService = new CartService($client);

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -2,13 +2,14 @@
 
 use BoldApps\ShopifyToolkit\Models\User as ShopifyUser;
 use BoldApps\ShopifyToolkit\Services\User as UserService;
+use PHPUnit\Framework\TestCase;
 
-class UserTest extends \PHPUnit\Framework\TestCase
+class UserTest extends TestCase
 {
     /** @var UserService */
     private $userService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var \BoldApps\ShopifyToolkit\Services\Client $client */
         $client = $this->createMock(\BoldApps\ShopifyToolkit\Services\Client::class);
@@ -18,7 +19,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyRefundSerializesProperly()
+    public function shopifyRefundSerializesProperly()
     {
         $userEntity = new ShopifyUser();
         $userEntity->setId(55347909);
@@ -47,7 +48,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyUserDeserializesProperly()
+    public function shopifyUserDeserializesProperly()
     {
         $expected = new ShopifyUser();
         $expected->setId(55347909);

--- a/tests/VariantTest.php
+++ b/tests/VariantTest.php
@@ -1,15 +1,16 @@
 <?php
 
-use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Models\Variant as ShopifyVariant;
+use BoldApps\ShopifyToolkit\Services\Client;
 use BoldApps\ShopifyToolkit\Services\Variant as VariantService;
+use PHPUnit\Framework\TestCase;
 
-class VariantTest extends \PHPUnit\Framework\TestCase
+class VariantTest extends TestCase
 {
     /** @var VariantService */
     private $variantService;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** @var Client $client */
         $client = $this->createMock(Client::class);
@@ -19,7 +20,7 @@ class VariantTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyVariantSerializesProperly()
+    public function shopifyVariantSerializesProperly()
     {
         $variantEntity = $this->createVariantEntity();
 
@@ -32,7 +33,7 @@ class VariantTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyVariantDeserializesProperly()
+    public function shopifyVariantDeserializesProperly()
     {
         $variantJson = $this->getVariantJson();
         $jsonArray = (array) json_decode($variantJson, true);
@@ -46,7 +47,7 @@ class VariantTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function ShopifyVariantWithoutInventorySerializesProperly()
+    public function shopifyVariantWithoutInventorySerializesProperly()
     {
         $variantEntity = $this->createVariantEntity();
 


### PR DESCRIPTION
Updated dependencies:
- phpunit from 5.5 (not supported) to 8.*
- php-cs-fixer from 2.13 to 2.18.2
- Illuminate/support from 7.* to 8.*
- Guzzlehttp/guzzle from 6.2 (some 6.2* are not supported anymore) to 7.1

Updated functions definitions and PHP Doc