### PR TITLE
Updated Location Model and Test to include the active property

### DIFF
--- a/src/Models/Location.php
+++ b/src/Models/Location.php
@@ -39,6 +39,9 @@ class Location implements Serializeable, \JsonSerializable
     /** @var bool */
     protected $legacy;
 
+    /** @var bool */
+    protected $active;
+
     /** @var string */
     protected $name;
 
@@ -215,6 +218,22 @@ class Location implements Serializeable, \JsonSerializable
     public function setLegacy($legacy)
     {
         $this->legacy = $legacy;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getActive()
+    {
+        return $this->active;
+    }
+
+    /**
+     * @param bool $active
+     */
+    public function setActive($active)
+    {
+        $this->active = $active;
     }
 
     /**

--- a/tests/LocationTest.php
+++ b/tests/LocationTest.php
@@ -61,6 +61,7 @@ class LocationTest extends \PHPUnit\Framework\TestCase
             "country_name": "United States",
             "province_code": "NY",
             "legacy": false,
+            "active": true,
             "admin_graphql_api_id": "gid://shopify/Location/487838322"
         }';
     }
@@ -82,6 +83,7 @@ class LocationTest extends \PHPUnit\Framework\TestCase
             'country_name' => 'United States',
             'province_code' => 'NY',
             'legacy' => false,
+            'active' => true,
             'admin_graphql_api_id' => 'gid://shopify/Location/487838322',
         ];
     }


### PR DESCRIPTION
Shopify locations have an 'active' property that allows merchants to deactivate primary locations if a secondary location is active and transfer inventory to the latter. 
Any apps that use the primary or first location without checking if it is active and use that to set a product's inventory can throw an error.