### PR TITLE
update shopify API to 2021-07

### DIFF
--- a/src/Models/Shop.php
+++ b/src/Models/Shop.php
@@ -147,9 +147,6 @@ class Shop implements Serializeable, \JsonSerializable
     /** @var string */
     protected $setupRequired;
 
-    /** @var string */
-    protected $forceSsl;
-
     /**
      * @return string
      */
@@ -583,13 +580,5 @@ class Shop implements Serializeable, \JsonSerializable
     public function getSetupRequired()
     {
         return $this->setupRequired;
-    }
-
-    /**
-     * @return string
-     */
-    public function getForceSsl()
-    {
-        return $this->forceSsl;
     }
 }

--- a/src/Services/Base.php
+++ b/src/Services/Base.php
@@ -9,7 +9,7 @@ abstract class Base
 {
     const BASE_API_PATH = 'admin/api/%s';
 
-    const DEFAULT_API_VERSION = '2020-04';
+    const DEFAULT_API_VERSION = '2021-07';
 
     /** @var string */
     protected $shopifyApiVersion = self::DEFAULT_API_VERSION;

--- a/tests/Services/CustomerSavedSearchTest.php
+++ b/tests/Services/CustomerSavedSearchTest.php
@@ -34,7 +34,7 @@ class CustomerSavedSearchTest extends TestCase
               ],
         ];
 
-        $expectedUrl = 'admin/api/2020-04/customer_saved_searches/123456789.json';
+        $expectedUrl = 'admin/api/2021-07/customer_saved_searches/123456789.json';
         $expectedCustomerSavedSearch = new CustomerSavedSearch();
         $expectedCustomerSavedSearch->setId(123456789);
         $expectedCustomerSavedSearch->setName('Accepts Marketing');


### PR DESCRIPTION
[ Why / how ]
  - removing breaking force_ssl fields from latest Shopify API changes from Shop.php
  - force_ssl is now always true so the field was removed
  - updating the default api version to 2021-07

​