### PR TITLE
Add customer segments to price rules model

### DIFF
--- a/src/Models/PriceRule.php
+++ b/src/Models/PriceRule.php
@@ -46,6 +46,9 @@ class PriceRule implements Serializeable, \JsonSerializable
     protected $prerequisiteSavedSearchIds;
 
     /** @var array */
+    protected $customerSegmentPrerequisiteIds;
+
+    /** @var array */
     protected $prerequisiteCustomerIds;
 
     /** @var array */
@@ -286,6 +289,22 @@ class PriceRule implements Serializeable, \JsonSerializable
     public function setPrerequisiteSavedSearchIds($prerequisiteSavedSearchIds)
     {
         $this->prerequisiteSavedSearchIds = $prerequisiteSavedSearchIds;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCustomerSegmentPrerequisiteIds()
+    {
+        return $this->customerSegmentPrerequisiteIds;
+    }
+
+    /**
+     * @param array
+     */
+    public function setCustomerSegmentPrerequisiteIds($customerSegmentPrerequisiteIds)
+    {
+        $this->customerSegmentPrerequisiteIds = $customerSegmentPrerequisiteIds;
     }
 
     /**

--- a/tests/PriceRuleTest.php
+++ b/tests/PriceRuleTest.php
@@ -43,6 +43,20 @@ class PriceRuleTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * @test
+     */
+    public function ShopifyPriceRuleDeserializesProperlyWithCustomerSegments()
+    {
+        $priceRuleJson = $this->getPriceRuleJsonWithCustomerSegment();
+        $jsonArray = (array) json_decode($priceRuleJson, true);
+
+        $expected = $this->priceRuleService->createFromArray($this->getPriceRuleArrayWithCustomerSegment());
+        $actual = $this->priceRuleService->unserializeModel($jsonArray, ShopifyPriceRule::class);
+
+        $this->assertEquals($expected, $actual);
+    }
+
     private function getPriceRuleJson()
     {
         return '{
@@ -104,6 +118,83 @@ class PriceRuleTest extends \PHPUnit\Framework\TestCase
             'entitled_collection_ids' => array(),
             'entitled_country_ids' => array(),
             'prerequisite_saved_search_ids' => array(),
+            'customer_segment_prerequisite_ids' => null,
+            'prerequisite_customer_ids' => array(),
+            'prerequisite_product_ids' => array(),
+            'prerequisite_variant_ids' => array(),
+            'prerequisite_collection_ids' => array(),
+            'prerequisite_subtotal_range' => array('greater_than_or_equal_to' => '10.0'),
+            'prerequisite_quantity_range' => array('greater_than_or_equal_to' => 5),
+            'prerequisite_shipping_price_range' => array('less_than_or_equal_to' => '17.0'),
+            'prerequisite_to_entitlement_quantity_ratio' => array('prerequisite_quantity' => 1, 'entitled_quantity' => 2),
+            'prerequisite_to_entitlement_purchase' => array('prerequisite_amount' => 20),
+            'title' => 'WINTER SALE',
+        ];
+    }
+
+    private function getPriceRuleJsonWithCustomerSegment()
+    {
+        return '{
+            "id": 507328175,
+            "value_type": "fixed_amount",
+            "value": "-10.0",
+            "customer_selection": "all",
+            "target_type": "line_item",
+            "target_selection": "all",
+            "allocation_method": "across",
+            "allocation_limit": 3,
+            "once_per_customer": false,
+            "usage_limit": null,
+            "starts_at": "2017-09-06T16:23:01-04:00",
+            "ends_at": "2017-09-18T16:23:01-04:00",
+            "created_at": "2017-09-12T16:23:01-04:00",
+            "updated_at": "2017-09-12T16:23:01-04:00",
+            "entitled_product_ids": [],
+            "entitled_variant_ids": [],
+            "entitled_collection_ids": [],
+            "entitled_country_ids": [],
+            "prerequisite_saved_search_ids": [],
+            "customer_segment_prerequisite_ids": [],
+            "prerequisite_customer_ids": [],
+            "prerequisite_product_ids": [],
+            "prerequisite_variant_ids": [],
+            "prerequisite_collection_ids": [],
+            "prerequisite_subtotal_range": {"greater_than_or_equal_to": "10.0"},
+            "prerequisite_quantity_range": {"greater_than_or_equal_to": 5},
+            "prerequisite_shipping_price_range": {"less_than_or_equal_to": "17.0"},
+            "prerequisite_to_entitlement_quantity_ratio": {
+                "prerequisite_quantity": 1,
+                "entitled_quantity": 2
+            },
+            "prerequisite_to_entitlement_purchase": {
+              "prerequisite_amount": 20
+            },
+            "title": "WINTER SALE"
+        }';
+    }
+
+    private function getPriceRuleArrayWithCustomerSegment()
+    {
+        return [
+            'id' => 507328175,
+            'value_type' => 'fixed_amount',
+            'value' => '-10.0',
+            'customer_selection' => 'all',
+            'target_type' => 'line_item',
+            'target_selection' => 'all',
+            'allocation_method' => 'across',
+            'allocation_limit' => 3,
+            'once_per_customer' => false,
+            'starts_at' => '2017-09-06T16:23:01-04:00',
+            'ends_at' => '2017-09-18T16:23:01-04:00',
+            'created_at' => '2017-09-12T16:23:01-04:00',
+            'updated_at' => '2017-09-12T16:23:01-04:00',
+            'entitled_product_ids' => array(),
+            'entitled_variant_ids' => array(),
+            'entitled_collection_ids' => array(),
+            'entitled_country_ids' => array(),
+            'prerequisite_saved_search_ids' => array(),
+            'customer_segment_prerequisite_ids' => array(),
             'prerequisite_customer_ids' => array(),
             'prerequisite_product_ids' => array(),
             'prerequisite_variant_ids' => array(),


### PR DESCRIPTION
- Shopify recently changed their customer group modeling to use
  "Customer Segments" rather than customer saved searches.
- Customer segment ids will show up on the price rule model as an array.
- Added test coverage for the new property on the price rule model.
- Since this data will *only* be available in the 2022-04 version of the
  api, I've preserved the test that does not include the customer
  segment data, and added another test that does include it.