### PR TITLE
Remove valueType from metafield

### DIFF
--- a/src/Models/Metafield.php
+++ b/src/Models/Metafield.php
@@ -21,13 +21,6 @@ class Metafield implements Serializeable, \JsonSerializable
     /** @var string */
     protected $value;
 
-    /**
-     * @deprecated use $type
-     *
-     * @var string
-     */
-    protected $valueType;
-
     /** @var string */
     protected $type;
 
@@ -111,31 +104,12 @@ class Metafield implements Serializeable, \JsonSerializable
     }
 
     /**
-     * @deprecated use $type
-     * @return string
-     */
-    public function getValueType()
-    {
-        return $this->valueType;
-    }
-
-    /**
-     * @deprecated use $type
-     * @param string $valueType
-     */
-    public function setValueType($valueType)
-    {
-        $this->valueType = $valueType;
-    }
-
-    /**
      * @return string
      */
     public function getType()
     {
         return $this->type;
     }
-
 
     /**
      * @param string $type


### PR DESCRIPTION
I'm still getting errors from the shopify API from the valueType field. Seems like shopify is removing it entirely. Last merge marked it as deprecated, but this one would definitely be a breaking change



Breaking Change Guide

1. `BoldApps\ShopifyToolkit\Models\Metafield::valueType` has been
   removed and should be replaced with `BoldApps\ShopifyToolkit\Models\Metafield::type`

2. `BoldApps\ShopifyToolkit\Models\Metafield::getValueType` and `BoldApps\ShopifyToolkit\Models\Metafield::setValueType` have been removed
    and should be replaced with `BoldApps\ShopifyToolkit\Models\Metafield::getType` and `BoldApps\ShopifyToolkit\Models\Metafield::setType`

3. The type field has new types than ones that existed in valueTypes, you will need to update to a supported one from the list on this page : https://shopify.dev/apps/metafields/types#metafield-value_type-deprecation