### PR TITLE
Updated default API version to `2023-01`

### DIFF
--- a/src/Services/Base.php
+++ b/src/Services/Base.php
@@ -9,7 +9,7 @@ abstract class Base
 {
     public const BASE_API_PATH = 'admin/api/%s';
 
-    public const DEFAULT_API_VERSION = '2021-07';
+    public const DEFAULT_API_VERSION = '2023-01';
 
     /** @var string */
     protected $shopifyApiVersion = self::DEFAULT_API_VERSION;


### PR DESCRIPTION
Updating default API version to `2023-01` to avoid deprecated calls when version is not specified. No breaking changes were observed. A separate MR will be created for changes related to FullfillmentOrder.