### PR TITLE
Revert "Added fulfillment property for variant"

### DIFF
--- a/src/Models/Variant.php
+++ b/src/Models/Variant.php
@@ -90,9 +90,6 @@ class Variant implements Serializeable, \JsonSerializable
     /** @var array */
     protected $metafields;
 
-    /** @var string */
-    protected $fulfillmentService = 'manual';
-
     /**
      * @return string
      */
@@ -523,21 +520,5 @@ class Variant implements Serializeable, \JsonSerializable
     public function setMetafields($metafields)
     {
         $this->metafields = $metafields;
-    }
-
-    /**
-     * @return string
-     */
-    public function getFulfillmentService()
-    {
-        return $this->fulfillmentService;
-    }
-
-    /**
-     * @param string $fulfillmentService
-     */
-    public function setFulfillmentService($fulfillmentService): void
-    {
-        $this->fulfillmentService = $fulfillmentService;
     }
 }

--- a/tests/ProductTest.php
+++ b/tests/ProductTest.php
@@ -306,7 +306,6 @@ class ProductTest extends TestCase
                     'inventory_item_id' => 808950810,
                     'old_inventory_quantity' => 10,
                     'requires_shipping' => true,
-                    'fulfillment_service' => 'manual',
                 ],
                 [
                     'id' => 49148385,
@@ -329,7 +328,6 @@ class ProductTest extends TestCase
                     'inventory_item_id' => 49148385,
                     'old_inventory_quantity' => 20,
                     'requires_shipping' => true,
-                    'fulfillment_service' => 'manual',
                 ],
                 [
                     'id' => 39072856,
@@ -352,7 +350,6 @@ class ProductTest extends TestCase
                     'inventory_item_id' => 39072856,
                     'old_inventory_quantity' => 30,
                     'requires_shipping' => true,
-                    'fulfillment_service' => 'manual',
                 ],
                 [
                     'id' => 457924702,
@@ -375,7 +372,6 @@ class ProductTest extends TestCase
                     'inventory_item_id' => 457924702,
                     'old_inventory_quantity' => 40,
                     'requires_shipping' => true,
-                    'fulfillment_service' => 'manual',
                 ],
             ],
             'options' => [

--- a/tests/VariantTest.php
+++ b/tests/VariantTest.php
@@ -119,7 +119,6 @@ class VariantTest extends TestCase
             'weight_unit' => 'kg',
             'old_inventory_quantity' => 0,
             'requires_shipping' => true,
-            'fulfillment_service' => 'manual',
         ];
     }
 
@@ -144,7 +143,6 @@ class VariantTest extends TestCase
             'weight' => '3',
             'weight_unit' => 'kg',
             'requires_shipping' => true,
-            'fulfillment_service' => 'manual',
         ];
     }
 }


### PR DESCRIPTION
Reverts bold-commerce/bold-shopify-toolkit#157

This field has been deprecated and previously removed. It doesn't make sense to readd the field. Stores recieving fulfillment service related error on variant create/update should set a default fullfillment service or fix the impacted variant or products.