### PR TITLE
Removed duplicate code and make versioned api call to get All themes

### DIFF
--- a/src/Services/Theme.php
+++ b/src/Services/Theme.php
@@ -64,13 +64,7 @@ class Theme extends Base
      */
     public function getAll($filter = [])
     {
-        $raw = $this->client->get('admin/themes.json', $filter);
-
-        $themes = array_map(function ($theme) {
-            return $this->unserializeModel($theme, ShopifyTheme::class);
-        }, $raw['themes']);
-
-        return new Collection($themes);
+        return $this->getByParams($filter);
     }
 
     /**


### PR DESCRIPTION
* Removed duplicate code from `getAll` as after adding `{$this->getApiBasePath()}` in getAll function code was identical to `getByParams` function
* This change also allows us to make version api call to get all themes