### PR TITLE
Don't send empty variables in POST to avoid 400 error from shopify

### DIFF
--- a/src/Services/GraphQL.php
+++ b/src/Services/GraphQL.php
@@ -6,6 +6,11 @@ class GraphQL extends Base
 {
     public function query($query, $variables = [])
     {
-        return $this->client->post("{$this->getApiBasePath()}/graphql.json", [], ['query' => $query, 'variables' => $variables]);
+        $data = [];
+        $data['query'] = $query;
+        if (!empty($variables)) {
+            $data['variables'] = $variables;
+        }
+        return $this->client->post("{$this->getApiBasePath()}/graphql.json", [], $data);
     }
 }


### PR DESCRIPTION
Shopify throws 400 error if variables are empty in graphql post request