### PR TITLE
SHOP-5205 Shopify API version 2024-04

### DIFF
--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -23,12 +23,6 @@ class Order implements Serializeable, \JsonSerializable
     protected $cancelledAt;
 
     /** @var string */
-    protected $cartToken;
-
-    /** @var string */
-    protected $checkoutToken;
-
-    /** @var string */
     protected $closedAt;
 
     /** @var bool */
@@ -90,12 +84,6 @@ class Order implements Serializeable, \JsonSerializable
 
     /** @var bool */
     protected $test;
-
-    /** @var string */
-    protected $token;
-
-    /** @var float */
-    protected $totalDiscounts;
 
     /** @var float */
     protected $totalLineItemsPrice;
@@ -245,22 +233,6 @@ class Order implements Serializeable, \JsonSerializable
     /**
      * @return string
      */
-    public function getCartToken()
-    {
-        return $this->cartToken;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCheckoutToken()
-    {
-        return $this->checkoutToken;
-    }
-
-    /**
-     * @return string
-     */
     public function getClosedAt()
     {
         return $this->closedAt;
@@ -400,22 +372,6 @@ class Order implements Serializeable, \JsonSerializable
     public function getTest()
     {
         return $this->test;
-    }
-
-    /**
-     * @return string
-     */
-    public function getToken()
-    {
-        return $this->token;
-    }
-
-    /**
-     * @return float
-     */
-    public function getTotalDiscounts()
-    {
-        return $this->totalDiscounts;
     }
 
     /**
@@ -715,22 +671,6 @@ class Order implements Serializeable, \JsonSerializable
     }
 
     /**
-     * @param string $cartToken
-     */
-    public function setCartToken($cartToken)
-    {
-        $this->cartToken = $cartToken;
-    }
-
-    /**
-     * @param string $checkoutToken
-     */
-    public function setCheckoutToken($checkoutToken)
-    {
-        $this->checkoutToken = $checkoutToken;
-    }
-
-    /**
      * @param string $closedAt
      */
     public function setClosedAt($closedAt)
@@ -888,22 +828,6 @@ class Order implements Serializeable, \JsonSerializable
     public function setTest($test)
     {
         $this->test = $test;
-    }
-
-    /**
-     * @param string $token
-     */
-    public function setToken($token)
-    {
-        $this->token = $token;
-    }
-
-    /**
-     * @param float $totalDiscounts
-     */
-    public function setTotalDiscounts($totalDiscounts)
-    {
-        $this->totalDiscounts = $totalDiscounts;
     }
 
     /**

--- a/src/Services/Base.php
+++ b/src/Services/Base.php
@@ -9,7 +9,7 @@ abstract class Base
 {
     public const BASE_API_PATH = 'admin/api/%s';
 
-    public const DEFAULT_API_VERSION = '2024-01';
+    public const DEFAULT_API_VERSION = '2024-04';
 
     /** @var string */
     protected $shopifyApiVersion = self::DEFAULT_API_VERSION;


### PR DESCRIPTION
- Shopify API version 2024-04
- Remove the [deprecated](https://shopify.dev/docs/api/admin-rest/2024-04/resources/order#resource-object) Order properties: `cart_token`, `checkout_token`, `total_discounts`, `token`.